### PR TITLE
Adding neomorphic switch

### DIFF
--- a/example/lib/widgets.dart
+++ b/example/lib/widgets.dart
@@ -293,7 +293,7 @@ class _ContainersListPageState extends State<WidgetsPage> {
                     style: TextStyle(color: Colors.black),
                   ),
                 ),
-                style: NeumorphicStyle(shape: NeumorphicShape.emboss, depth: 8),
+                style: NeumorphicStyle(shape: NeumorphicShape.flat, depth: 8),
               ),
               Padding(
                 padding: const EdgeInsets.symmetric(horizontal: 18.0),

--- a/example/lib/widgets.dart
+++ b/example/lib/widgets.dart
@@ -254,7 +254,7 @@ class _ContainersListPageState extends State<WidgetsPage> {
         value: _switchConvexEnabled,
         style: NeumorphicSwitchStyle(
           trackDepth: -3.0,
-          thumbShape: NeumorphicShape.convex, // concave or flat with elevation
+          thumbShape: NeumorphicShape.convex,
         ),
         onChanged: (value) {
           setState(() {

--- a/example/lib/widgets.dart
+++ b/example/lib/widgets.dart
@@ -11,7 +11,9 @@ class WidgetsPage extends StatefulWidget {
 
 class _ContainersListPageState extends State<WidgetsPage> {
   int _groupValue;
-
+  bool _switchConcaveEnabled = false;
+  bool _switchConvexEnabled = false;
+  bool _switchFlatEnabled = false;
   Widget _buildProgress() {
     return Row(
       children: <Widget>[
@@ -218,6 +220,51 @@ class _ContainersListPageState extends State<WidgetsPage> {
     );
   }
 
+  Widget _buildSwitches() {
+    return Row(children: <Widget>[
+      Text("Switch"),
+      SizedBox(width: 15),
+      NeumorphicSwitch(
+        value: _switchConcaveEnabled,
+        style: NeumorphicSwitchStyle(
+          trackDepth: -3.0,
+          thumbShape: NeumorphicShape.concave, // concave or flat with elevation
+        ),
+        onChanged: (value) {
+          setState(() {
+            _switchConcaveEnabled = value;
+          });
+        },
+      ),
+      SizedBox(width: 15),
+      NeumorphicSwitch(
+        value: _switchFlatEnabled,
+        style: NeumorphicSwitchStyle(
+          trackDepth: -3.0,
+          thumbShape: NeumorphicShape.flat, // concave or flat with elevation
+        ),
+        onChanged: (value) {
+          setState(() {
+            _switchFlatEnabled = value;
+          });
+        },
+      ),
+      SizedBox(width: 15),
+      NeumorphicSwitch(
+        value: _switchConvexEnabled,
+        style: NeumorphicSwitchStyle(
+          trackDepth: -3.0,
+          thumbShape: NeumorphicShape.convex, // concave or flat with elevation
+        ),
+        onChanged: (value) {
+          setState(() {
+            _switchConvexEnabled = value;
+          });
+        },
+      ),
+    ]);
+  }
+
   @override
   Widget build(BuildContext context) {
     return NeumorphicThemeProvider(
@@ -267,6 +314,8 @@ class _ContainersListPageState extends State<WidgetsPage> {
                     _buildChecks(),
                     SizedBox(height: 30),
                     _buildSeekbar(),
+                    SizedBox(height: 30),
+                    _buildSwitches(),
                     SizedBox(height: 30),
                   ],
                 ),

--- a/lib/flutter_neumorphic.dart
+++ b/lib/flutter_neumorphic.dart
@@ -8,6 +8,7 @@ export 'widget/indicator.dart';
 export 'widget/checkbox.dart';
 export 'widget/slider.dart';
 export 'widget/progress.dart';
+export 'widget/switch.dart';
 export 'theme.dart';
 export 'NeumorphicBoxShape.dart';
 export 'shape.dart';

--- a/lib/widget/switch.dart
+++ b/lib/widget/switch.dart
@@ -1,0 +1,225 @@
+import 'package:flutter/widgets.dart';
+import 'package:flutter_neumorphic/NeumorphicBoxShape.dart';
+import 'package:flutter_neumorphic/flutter_neumorphic.dart';
+
+// Constants below are for easy scaling tests.
+// Can be removed later.
+const double SCALE = 1.0;
+const double TRACK_WIDTH = 90 * SCALE;
+const double TRACK_HEIGHT = 52 * SCALE;
+const double THUMB_WIDTH = 30 * SCALE;
+const double THUMB_HEIGHT = 30 * SCALE;
+const double THUMB_CONTAINER_WIDTH = 90 * SCALE;
+const double THUMB_CONTAINER_HEIGHT = 37 * SCALE;
+
+class NeumorphicSwitchStyle {
+  final double trackDepth;
+  final Color activeTrackColor;
+  final Color inactiveTrackColor;
+  final Color activeThumbColor;
+  final Color inactiveThumbColor;
+  final NeumorphicShape thumbShape;
+
+  const NeumorphicSwitchStyle({
+    this.trackDepth,
+    this.thumbShape,
+    this.activeTrackColor,
+    this.inactiveTrackColor,
+    this.activeThumbColor,
+    this.inactiveThumbColor,
+  });
+
+  // @override
+  // bool operator ==(Object other) =>
+  //     identical(this, other) ||
+  //     other is ProgressStyle && runtimeType == other.runtimeType && trackDepth == other.;
+
+  // @override
+  // int get hashCode => trackDepth.hashCode;
+// && borderRadius == other.borderRadius && accent == other.accent && variant == other.variant;
+
+}
+
+class NeumorphicSwitch extends StatefulWidget {
+  final bool value;
+  final ValueChanged<bool> onChanged;
+  final NeumorphicSwitchStyle style;
+
+  const NeumorphicSwitch({
+    this.style,
+    Key key,
+    this.value = false,
+    this.onChanged,
+  }) : super(key: key);
+
+  @override
+  _NeumorphicSwitchState createState() => _NeumorphicSwitchState();
+}
+
+class _NeumorphicSwitchState extends State<NeumorphicSwitch>
+    with SingleTickerProviderStateMixin {
+  Animation<Alignment> animation;
+  AnimationController controller;
+
+  @override
+  void initState() {
+    super.initState();
+    controller = AnimationController(
+        duration: const Duration(milliseconds: 200), vsync: this);
+    animation = Tween<Alignment>(
+            begin: Alignment.centerLeft, end: Alignment.centerRight)
+        .animate(controller);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final NeumorphicTheme theme =
+        NeumorphicThemeProvider.findNeumorphicTheme(context);
+    return SizedBox(
+      height: TRACK_HEIGHT,
+      width: TRACK_WIDTH,
+      child: GestureDetector(
+        onTap: () {
+          // animation breaking prevention
+          if (controller.isAnimating) {
+            return;
+          }
+          if (widget.value == false) {
+            controller.forward();
+            _notifyOnChange(true);
+          } else {
+            controller.reverse();
+            _notifyOnChange(false);
+          }
+        },
+        child: Neumorphic(
+          shape: NeumorphicBoxShape.stadium(),
+          style: NeumorphicStyle(
+              depth: (widget.style.trackDepth ?? theme.depth) * SCALE,
+              shape: NeumorphicShape.emboss,
+              baseColor: _getTrackColor(theme)),
+          child: AnimatedThumb(
+            animation: animation,
+            shape: _getThumbShape(),
+            thumbColor: _getThumbColor(theme),
+          ),
+        ),
+      ),
+    );
+  }
+
+  NeumorphicShape _getThumbShape() {
+    if (widget.style.thumbShape == null) {
+      return NeumorphicShape.flat;
+    }
+    return widget.style.thumbShape;
+  }
+
+  Color _getTrackColor(NeumorphicTheme theme) {
+    return widget.value == true
+        ? widget.style.activeTrackColor ?? theme.accentColor
+        : widget.style.inactiveTrackColor ?? theme.baseColor;
+  }
+
+  Color _getThumbColor(NeumorphicTheme theme) {
+    Color color = widget.value == true
+        ? widget.style.activeThumbColor
+        : widget.style.inactiveThumbColor;
+    return color ?? theme.baseColor;
+  }
+
+  void _notifyOnChange(bool newValue) {
+    if (widget.onChanged != null) {
+      widget.onChanged(newValue);
+    }
+  }
+
+  @override
+  void dispose() {
+    controller.dispose();
+    super.dispose();
+  }
+}
+
+class AnimatedThumb extends AnimatedWidget {
+  final Color thumbColor;
+  final NeumorphicShape shape;
+  AnimatedThumb(
+      {Key key, Animation<Alignment> animation, this.thumbColor, this.shape})
+      : super(key: key, listenable: animation);
+
+  @override
+  Widget build(BuildContext context) {
+    final animation = listenable as Animation<Alignment>;
+    final NeumorphicTheme theme =
+        NeumorphicThemeProvider.findNeumorphicTheme(context);
+    // This Container is actually the inner track containing the thumb
+    return Container(
+      height: THUMB_CONTAINER_HEIGHT,
+      width: THUMB_CONTAINER_WIDTH,
+      child: Align(
+        alignment: animation.value,
+        child: Neumorphic(
+          shape: NeumorphicBoxShape.circle(),
+          style: NeumorphicStyle(
+            shape: shape,
+            curveFactor: _getThumbCurveFactor(theme),
+            intensity: _getThumbIntensity(theme),
+            depth: _getThumbDepth(theme),
+            baseColor: thumbColor,
+          ),
+          child: SizedBox(
+            height: THUMB_HEIGHT,
+            width: THUMB_WIDTH,
+          ),
+        ),
+      ),
+    );
+  }
+
+  /// Returns the proper curveFactor according to the given shape.
+  double _getThumbCurveFactor(NeumorphicTheme theme) {
+    if (shape == null) {
+      return theme.curveFactor;
+    }
+    switch (shape) {
+      case NeumorphicShape.concave:
+        return 3.0;
+      default:
+        return theme.curveFactor;
+    }
+  }
+
+  /// Returns the proper depth according to the given shape.
+  double _getThumbDepth(NeumorphicTheme theme) {
+    if (shape == null) {
+      return theme.depth;
+    }
+    switch (shape) {
+      case NeumorphicShape.concave:
+      case NeumorphicShape.convex:
+      case NeumorphicShape.flat:
+        return 4.0;
+      case NeumorphicShape.emboss:
+        return -2.0;
+      default:
+        return theme.depth;
+    }
+  }
+
+  /// Returns the proper intensity according to the given shape.
+  double _getThumbIntensity(NeumorphicTheme theme) {
+    if (shape == null) {
+      return theme.intensity;
+    }
+    switch (shape) {
+      case NeumorphicShape.concave:
+      case NeumorphicShape.convex:
+      case NeumorphicShape.flat:
+        return 4.0;
+      case NeumorphicShape.emboss:
+      default:
+        return theme.intensity;
+    }
+  }
+}

--- a/lib/widget/switch.dart
+++ b/lib/widget/switch.dart
@@ -28,16 +28,6 @@ class NeumorphicSwitchStyle {
     this.activeThumbColor,
     this.inactiveThumbColor,
   });
-
-  // @override
-  // bool operator ==(Object other) =>
-  //     identical(this, other) ||
-  //     other is ProgressStyle && runtimeType == other.runtimeType && trackDepth == other.;
-
-  // @override
-  // int get hashCode => trackDepth.hashCode;
-// && borderRadius == other.borderRadius && accent == other.accent && variant == other.variant;
-
 }
 
 class NeumorphicSwitch extends StatefulWidget {

--- a/lib/widget/switch.dart
+++ b/lib/widget/switch.dart
@@ -86,7 +86,7 @@ class _NeumorphicSwitchState extends State<NeumorphicSwitch>
           shape: NeumorphicBoxShape.stadium(),
           style: NeumorphicStyle(
               depth: (widget.style.trackDepth ?? theme.depth) * SCALE,
-              shape: NeumorphicShape.emboss,
+              shape: NeumorphicShape.flat,
               baseColor: _getTrackColor(theme)),
           child: AnimatedThumb(
             animation: animation,
@@ -190,8 +190,6 @@ class AnimatedThumb extends AnimatedWidget {
       case NeumorphicShape.convex:
       case NeumorphicShape.flat:
         return 4.0;
-      case NeumorphicShape.emboss:
-        return -2.0;
       default:
         return theme.depth;
     }
@@ -207,7 +205,6 @@ class AnimatedThumb extends AnimatedWidget {
       case NeumorphicShape.convex:
       case NeumorphicShape.flat:
         return 4.0;
-      case NeumorphicShape.emboss:
       default:
         return theme.intensity;
     }


### PR DESCRIPTION
The first usable version of the `NeumorphicSwitch` widget is implemented.
The _track_ and the _thumb_ are built from a `Neumorphic` widget.

`NeumorphicSwitch` can take a `NeumorphicSwitchStyle` as input.
You can provide these values to the `NeumorphicSwitch` through the `NeumorphicSwitchStyle`:

  - trackDepth
  - thumbShape (concave, convex, flat)
  - activeTrackColor
  - inactiveTrackColor
  - activeThumbColor
  - inactiveThumbColor

If no `NeumorphicSwitchStyle` is provided, the switch will use the default theme values.

To use `NeumorphicSwitch` (concave mode):

```
    NeumorphicSwitch(
          value: _switchEnable,
          style: NeumorphicSwitchStyle(
            trackDepth: -3.0,
            thumbShape: NeumorphicShape.concave,
          ),
          onChanged: (value) {
            setState(() {
              _switchEnable = value;
            });
          },
    )
```

In flat mode:

```
    NeumorphicSwitch(
          value: _switchEnable,
          style: NeumorphicSwitchStyle(
            trackDepth: -3.0,
            thumbShape: NeumorphicShape.flat,
          ),
          onChanged: (value) {
            setState(() {
              _switchEnable = value;
            });
          },
    )
```

In convex mode:

```
    NeumorphicSwitch(
          value: _switchEnable,
          style: NeumorphicSwitchStyle(
            trackDepth: -3.0,
            thumbShape: NeumorphicShape.convex,
          ),
          onChanged: (value) {
            setState(() {
              _switchEnable = value;
            });
          },
    )
```

![Screenshot 2020-02-28 at 15 31 49](https://user-images.githubusercontent.com/4046239/75557596-9b695600-5a40-11ea-902c-49f06a62baab.png)
![Screenshot 2020-02-28 at 15 32 22](https://user-images.githubusercontent.com/4046239/75557592-9ad0bf80-5a40-11ea-9f26-a2fdb5242966.png)
