### PR TITLE
trigger click on tap up

### DIFF
--- a/lib/src/widget/button.dart
+++ b/lib/src/widget/button.dart
@@ -128,10 +128,6 @@ class _NeumorphicButtonState extends State<NeumorphicButton> {
       HapticFeedback.lightImpact();
     }
 
-    if (widget.onClick != null) {
-      widget.onClick();
-    }
-
     _resetIfTapUp();
   }
 
@@ -157,7 +153,7 @@ class _NeumorphicButtonState extends State<NeumorphicButton> {
   }
 
   bool get clickable {
-    return widget.onClick != null;
+    return widget.isEnabled && widget.onClick != null;
   }
 
   bool hasFinishedAnimationDown = false;
@@ -167,13 +163,14 @@ class _NeumorphicButtonState extends State<NeumorphicButton> {
   Widget build(BuildContext context) {
     return GestureDetector(
       onTapDown: (detail) {
-        if (widget.isEnabled) {
-          if (clickable && !pressed) {
-            _handlePress();
-          }
+        if (clickable && !pressed) {
+          _handlePress();
         }
       },
       onTapUp: (details) {
+        if (clickable) {
+          widget.onClick();
+        }
         hasTapUp = true;
         _resetIfTapUp();
       },


### PR DESCRIPTION
Click is currently triggered even when the tap is canceled. So I think the click should be triggered onTapUp (or onTap alternatively), anyway in the case of the tap gesture winning.