### PR TITLE
Fix for issue Neumorphic button issue 

### DIFF
--- a/lib/src/widget/button.dart
+++ b/lib/src/widget/button.dart
@@ -177,7 +177,7 @@ class _NeumorphicButtonState extends State<NeumorphicButton> {
 
   Widget _build(BuildContext context) {
     final appBarPresent = NeumorphicAppBarTheme.of(context) != null;
-    final appBarTheme = NeumorphicTheme.of(context)?.current?.appBarTheme;
+    final appBarTheme = NeumorphicTheme.currentTheme(context).appBarTheme;
 
     return GestureDetector(
       onTapDown: (detail) {


### PR DESCRIPTION
Fix for [issue](https://github.com/Idean/Flutter-Neumorphic/issues/169) 
The issue is because of the following line:
`final appBarTheme = NeumorphicTheme.of(context).current.appBarTheme;`
This should work, if I am using NeumorphicApp as the parent widget, which initialises NeumorphicTheme() but I do not want to use NeumorphicApp as my parent widget, hence NeumorphicTheme.of(context) will always be null.