### PR TITLE
code cleanup according to best practices.

### DIFF
--- a/example/lib/accessibility/neumorphic_accessibility.dart
+++ b/example/lib/accessibility/neumorphic_accessibility.dart
@@ -1,4 +1,4 @@
-import 'package:example/lib/color_selector.dart';
+import '../lib/color_selector.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_neumorphic/flutter_neumorphic.dart';
 

--- a/example/lib/main_home.dart
+++ b/example/lib/main_home.dart
@@ -1,5 +1,5 @@
-import 'package:example/tips/tips_home.dart';
-import 'package:example/widgets/widgets_home.dart';
+import 'tips/tips_home.dart';
+import 'widgets/widgets_home.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_neumorphic/flutter_neumorphic.dart';
 

--- a/example/lib/playground/neumorphic_playground.dart
+++ b/example/lib/playground/neumorphic_playground.dart
@@ -1,4 +1,4 @@
-import 'package:example/lib/color_selector.dart';
+import '../lib/color_selector.dart';
 import 'package:flutter_neumorphic/flutter_neumorphic.dart';
 
 class NeumorphicPlayground extends StatefulWidget {

--- a/example/lib/playground/text_playground.dart
+++ b/example/lib/playground/text_playground.dart
@@ -1,4 +1,4 @@
-import 'package:example/lib/color_selector.dart';
+import '../lib/color_selector.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_neumorphic/flutter_neumorphic.dart';
 

--- a/example/lib/sample_neumorphic_playground.dart
+++ b/example/lib/sample_neumorphic_playground.dart
@@ -1,4 +1,3 @@
-import 'package:example/lib/color_selector.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter_neumorphic/flutter_neumorphic.dart';
 

--- a/example/lib/samples/clock/clock_sample.dart
+++ b/example/lib/samples/clock/clock_sample.dart
@@ -1,7 +1,6 @@
-import 'package:example/lib/top_bar.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_neumorphic/flutter_neumorphic.dart';
-
+import '../../lib/top_bar.dart';
 import 'clock_second_sample.dart';
 
 class ClockSample extends StatelessWidget {

--- a/example/lib/samples/clock/clock_second_sample.dart
+++ b/example/lib/samples/clock/clock_second_sample.dart
@@ -1,6 +1,6 @@
-import 'package:example/lib/top_bar.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_neumorphic/flutter_neumorphic.dart';
+import '../../lib/top_bar.dart';
 
 class ClockAlarmPage extends StatelessWidget {
   @override

--- a/example/lib/samples/form_sample.dart
+++ b/example/lib/samples/form_sample.dart
@@ -1,7 +1,7 @@
-import 'package:example/lib/ThemeConfigurator.dart';
-import 'package:example/lib/top_bar.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_neumorphic/flutter_neumorphic.dart';
+import '../lib/ThemeConfigurator.dart';
+import '../lib/top_bar.dart';
 
 class FormSample extends StatelessWidget {
   @override

--- a/example/lib/samples/galaxy_sample.dart
+++ b/example/lib/samples/galaxy_sample.dart
@@ -1,7 +1,7 @@
-import 'package:example/lib/ThemeConfigurator.dart';
-import 'package:example/lib/top_bar.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_neumorphic/flutter_neumorphic.dart';
+import '../lib/ThemeConfigurator.dart';
+import '../lib/top_bar.dart';
 
 class GalaxySample extends StatelessWidget {
   @override

--- a/example/lib/samples/sample_home.dart
+++ b/example/lib/samples/sample_home.dart
@@ -1,13 +1,12 @@
-import 'package:example/lib/top_bar.dart';
-import 'package:example/samples/audio_player_sample.dart';
-import 'package:example/samples/calculator_sample.dart';
-import 'package:example/samples/clock/clock_sample.dart';
-import 'package:example/samples/credit_card_sample.dart';
-import 'package:example/samples/form_sample.dart';
-import 'package:example/samples/testla_sample.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_neumorphic/flutter_neumorphic.dart';
-
+import '../lib/top_bar.dart';
+import '../samples/audio_player_sample.dart';
+import '../samples/calculator_sample.dart';
+import '../samples/clock/clock_sample.dart';
+import '../samples/credit_card_sample.dart';
+import '../samples/form_sample.dart';
+import '../samples/testla_sample.dart';
 import 'galaxy_sample.dart';
 import 'widgets_sample.dart';
 

--- a/example/lib/tips/border/tips_border.dart
+++ b/example/lib/tips/border/tips_border.dart
@@ -1,8 +1,8 @@
-import 'package:example/lib/Code.dart';
-import 'package:example/lib/ThemeConfigurator.dart';
-import 'package:example/lib/top_bar.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_neumorphic/flutter_neumorphic.dart';
+import '../../lib/Code.dart';
+import '../../lib/ThemeConfigurator.dart';
+import '../../lib/top_bar.dart';
 
 class TipsBorderPage extends StatefulWidget {
   TipsBorderPage({Key key}) : super(key: key);

--- a/example/lib/tips/border/tips_emboss_inside_emboss.dart
+++ b/example/lib/tips/border/tips_emboss_inside_emboss.dart
@@ -1,8 +1,8 @@
-import 'package:example/lib/Code.dart';
-import 'package:example/lib/ThemeConfigurator.dart';
-import 'package:example/lib/top_bar.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_neumorphic/flutter_neumorphic.dart';
+import '../../lib/Code.dart';
+import '../../lib/ThemeConfigurator.dart';
+import '../../lib/top_bar.dart';
 
 class TipsRecursiveeEmbossPage extends StatefulWidget {
   TipsRecursiveeEmbossPage({Key key}) : super(key: key);

--- a/example/lib/tips/tips_home.dart
+++ b/example/lib/tips/tips_home.dart
@@ -1,7 +1,6 @@
-import 'package:example/lib/top_bar.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_neumorphic/flutter_neumorphic.dart';
-
+import '../lib/top_bar.dart';
 import 'border/tips_border.dart';
 import 'border/tips_emboss_inside_emboss.dart';
 

--- a/example/lib/widgets/background/widget_background.dart
+++ b/example/lib/widgets/background/widget_background.dart
@@ -1,8 +1,8 @@
-import 'package:example/lib/Code.dart';
-import 'package:example/lib/ThemeConfigurator.dart';
-import 'package:example/lib/top_bar.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_neumorphic/flutter_neumorphic.dart';
+import '../../lib/Code.dart';
+import '../../lib/ThemeConfigurator.dart';
+import '../../lib/top_bar.dart';
 
 class BackgroundWidgetPage extends StatefulWidget {
   BackgroundWidgetPage({Key key}) : super(key: key);

--- a/example/lib/widgets/button/widget_button.dart
+++ b/example/lib/widgets/button/widget_button.dart
@@ -1,9 +1,9 @@
-import 'package:example/lib/Code.dart';
-import 'package:example/lib/ThemeConfigurator.dart';
-import 'package:example/lib/color_selector.dart';
-import 'package:example/lib/top_bar.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_neumorphic/flutter_neumorphic.dart';
+import '../../lib/Code.dart';
+import '../../lib/ThemeConfigurator.dart';
+import '../../lib/color_selector.dart';
+import '../../lib/top_bar.dart';
 
 class ButtonWidgetPage extends StatefulWidget {
   ButtonWidgetPage({Key key}) : super(key: key);

--- a/example/lib/widgets/checkbox/widget_checkbox.dart
+++ b/example/lib/widgets/checkbox/widget_checkbox.dart
@@ -1,9 +1,9 @@
-import 'package:example/lib/Code.dart';
-import 'package:example/lib/ThemeConfigurator.dart';
-import 'package:example/lib/color_selector.dart';
-import 'package:example/lib/top_bar.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_neumorphic/flutter_neumorphic.dart';
+import '../../lib/Code.dart';
+import '../../lib/ThemeConfigurator.dart';
+import '../../lib/color_selector.dart';
+import '../../lib/top_bar.dart';
 
 class CheckboxWidgetPage extends StatefulWidget {
   CheckboxWidgetPage({Key key}) : super(key: key);

--- a/example/lib/widgets/container/widget_container.dart
+++ b/example/lib/widgets/container/widget_container.dart
@@ -1,9 +1,9 @@
-import 'package:example/lib/Code.dart';
-import 'package:example/lib/ThemeConfigurator.dart';
-import 'package:example/lib/color_selector.dart';
-import 'package:example/lib/top_bar.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_neumorphic/flutter_neumorphic.dart';
+import '../../lib/Code.dart';
+import '../../lib/ThemeConfigurator.dart';
+import '../../lib/color_selector.dart';
+import '../../lib/top_bar.dart';
 
 class ContainerWidgetPage extends StatefulWidget {
   ContainerWidgetPage({Key key}) : super(key: key);

--- a/example/lib/widgets/icon/widget_icon.dart
+++ b/example/lib/widgets/icon/widget_icon.dart
@@ -1,7 +1,7 @@
-import 'package:example/lib/ThemeConfigurator.dart';
-import 'package:example/lib/top_bar.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_neumorphic/flutter_neumorphic.dart';
+import '../../lib/ThemeConfigurator.dart';
+import '../../lib/top_bar.dart';
 
 class IconWidgetPage extends StatefulWidget {
   IconWidgetPage({Key key}) : super(key: key);

--- a/example/lib/widgets/indeterminate_progress/widget_indeterminate_progress.dart
+++ b/example/lib/widgets/indeterminate_progress/widget_indeterminate_progress.dart
@@ -1,9 +1,9 @@
-import 'package:example/lib/Code.dart';
-import 'package:example/lib/ThemeConfigurator.dart';
-import 'package:example/lib/color_selector.dart';
-import 'package:example/lib/top_bar.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_neumorphic/flutter_neumorphic.dart';
+import '../../lib/Code.dart';
+import '../../lib/ThemeConfigurator.dart';
+import '../../lib/color_selector.dart';
+import '../../lib/top_bar.dart';
 
 class IndeterminateProgressWidgetPage extends StatefulWidget {
   IndeterminateProgressWidgetPage({Key key}) : super(key: key);

--- a/example/lib/widgets/indicator/widget_indicator.dart
+++ b/example/lib/widgets/indicator/widget_indicator.dart
@@ -1,9 +1,9 @@
-import 'package:example/lib/Code.dart';
-import 'package:example/lib/ThemeConfigurator.dart';
-import 'package:example/lib/color_selector.dart';
-import 'package:example/lib/top_bar.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_neumorphic/flutter_neumorphic.dart';
+import '../../lib/Code.dart';
+import '../../lib/ThemeConfigurator.dart';
+import '../../lib/color_selector.dart';
+import '../../lib/top_bar.dart';
 
 import 'dart:math' show Random;
 

--- a/example/lib/widgets/progress/widget_progress.dart
+++ b/example/lib/widgets/progress/widget_progress.dart
@@ -1,8 +1,8 @@
-import 'package:example/lib/Code.dart';
-import 'package:example/lib/color_selector.dart';
-import 'package:example/lib/top_bar.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_neumorphic/flutter_neumorphic.dart';
+import '../../lib/Code.dart';
+import '../../lib/color_selector.dart';
+import '../../lib/top_bar.dart';
 
 import 'dart:math' show Random;
 

--- a/example/lib/widgets/radiobutton/widget_radio_button.dart
+++ b/example/lib/widgets/radiobutton/widget_radio_button.dart
@@ -1,8 +1,8 @@
-import 'package:example/lib/Code.dart';
-import 'package:example/lib/ThemeConfigurator.dart';
-import 'package:example/lib/top_bar.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_neumorphic/flutter_neumorphic.dart';
+import '../../lib/Code.dart';
+import '../../lib/ThemeConfigurator.dart';
+import '../../lib/top_bar.dart';
 
 class RadioButtonWidgetPage extends StatefulWidget {
   RadioButtonWidgetPage({Key key}) : super(key: key);

--- a/example/lib/widgets/range_slider/widget_range_slider.dart
+++ b/example/lib/widgets/range_slider/widget_range_slider.dart
@@ -1,9 +1,9 @@
-import 'package:example/lib/Code.dart';
-import 'package:example/lib/ThemeConfigurator.dart';
-import 'package:example/lib/color_selector.dart';
-import 'package:example/lib/top_bar.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_neumorphic/flutter_neumorphic.dart';
+import '../../lib/Code.dart';
+import '../../lib/ThemeConfigurator.dart';
+import '../../lib/color_selector.dart';
+import '../../lib/top_bar.dart';
 
 class RangeSliderWidgetPage extends StatefulWidget {
   RangeSliderWidgetPage({Key key}) : super(key: key);

--- a/example/lib/widgets/slider/widget_slider.dart
+++ b/example/lib/widgets/slider/widget_slider.dart
@@ -1,9 +1,9 @@
-import 'package:example/lib/Code.dart';
-import 'package:example/lib/ThemeConfigurator.dart';
-import 'package:example/lib/color_selector.dart';
-import 'package:example/lib/top_bar.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_neumorphic/flutter_neumorphic.dart';
+import '../../lib/Code.dart';
+import '../../lib/ThemeConfigurator.dart';
+import '../../lib/color_selector.dart';
+import '../../lib/top_bar.dart';
 
 class SliderWidgetPage extends StatefulWidget {
   SliderWidgetPage({Key key}) : super(key: key);

--- a/example/lib/widgets/switch/widget_switch.dart
+++ b/example/lib/widgets/switch/widget_switch.dart
@@ -1,9 +1,9 @@
-import 'package:example/lib/Code.dart';
-import 'package:example/lib/ThemeConfigurator.dart';
-import 'package:example/lib/color_selector.dart';
-import 'package:example/lib/top_bar.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_neumorphic/flutter_neumorphic.dart';
+import '../../lib/Code.dart';
+import '../../lib/ThemeConfigurator.dart';
+import '../../lib/color_selector.dart';
+import '../../lib/top_bar.dart';
 
 class SwitchWidgetPage extends StatefulWidget {
   SwitchWidgetPage({Key key}) : super(key: key);

--- a/example/lib/widgets/toggle/widget_toggle.dart
+++ b/example/lib/widgets/toggle/widget_toggle.dart
@@ -1,8 +1,8 @@
-import 'package:example/lib/Code.dart';
-import 'package:example/lib/ThemeConfigurator.dart';
-import 'package:example/lib/top_bar.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_neumorphic/flutter_neumorphic.dart';
+import '../../lib/Code.dart';
+import '../../lib/ThemeConfigurator.dart';
+import '../../lib/top_bar.dart';
 
 class ToggleWidgetPage extends StatefulWidget {
   ToggleWidgetPage({Key key}) : super(key: key);

--- a/example/lib/widgets/widgets_home.dart
+++ b/example/lib/widgets/widgets_home.dart
@@ -1,9 +1,8 @@
-import 'package:example/lib/top_bar.dart';
-import 'package:example/widgets/appbar/widget_app_bar.dart';
-import 'package:example/widgets/toggle/widget_toggle.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_neumorphic/flutter_neumorphic.dart';
-
+import '../lib/top_bar.dart';
+import '../widgets/appbar/widget_app_bar.dart';
+import '../widgets/toggle/widget_toggle.dart';
 import 'background/widget_background.dart';
 import 'button/widget_button.dart';
 import 'checkbox/widget_checkbox.dart';

--- a/lib/src/widget/app_bar.dart
+++ b/lib/src/widget/app_bar.dart
@@ -144,7 +144,7 @@ class NeumorphicAppBarState extends State<NeumorphicAppBar> {
     final bool canPop = parentRoute?.canPop ?? false;
     final bool useCloseButton =
         parentRoute is PageRoute<dynamic> && parentRoute.fullscreenDialog;
-    final ScaffoldState scaffold = Scaffold.maybeOf(context);
+    final ScaffoldState scaffold = Scaffold.of(context, nullOk: true);
     final bool hasDrawer = scaffold?.hasDrawer ?? false;
     final bool hasEndDrawer = scaffold?.hasEndDrawer ?? false;
 


### PR DESCRIPTION
- import package:example replaced with proper references.
- Scaffold.of(context, nullOk: true) used instead of unsupported Scaffold.maybeOf(context)