### PR TITLE
#201 - Null-Safety support

### DIFF
--- a/lib/src/colors.dart
+++ b/lib/src/colors.dart
@@ -37,7 +37,7 @@ class NeumorphicColors {
 
   NeumorphicColors._();
 
-  static Color decorationWhiteColor(Color color, {@required double intensity}) {
+  static Color decorationWhiteColor(Color color, {required double intensity}) {
     // intensity act on opacity;
     return _applyPercentageOnOpacity(
       maxColor: color,
@@ -45,7 +45,7 @@ class NeumorphicColors {
     );
   }
 
-  static Color decorationDarkColor(Color color, {@required double intensity}) {
+  static Color decorationDarkColor(Color color, {required double intensity}) {
     // intensity act on opacity;
     return _applyPercentageOnOpacity(
       maxColor: color,
@@ -53,7 +53,7 @@ class NeumorphicColors {
     );
   }
 
-  static Color embossWhiteColor(Color color, {@required double intensity}) {
+  static Color embossWhiteColor(Color color, {required double intensity}) {
     // intensity act on opacity;
     return _applyPercentageOnOpacity(
       maxColor: color,
@@ -61,7 +61,7 @@ class NeumorphicColors {
     );
   }
 
-  static Color embossDarkColor(Color color, {@required double intensity}) {
+  static Color embossDarkColor(Color color, {required double intensity}) {
     // intensity act on opacity;
     return _applyPercentageOnOpacity(
       maxColor: color,
@@ -69,14 +69,14 @@ class NeumorphicColors {
     );
   }
 
-  static Color gradientShaderDarkColor({@required double intensity}) {
+  static Color gradientShaderDarkColor({required double intensity}) {
     // intensity act on opacity;
     return _applyPercentageOnOpacity(
         maxColor: NeumorphicColors._gradientShaderDarkColor,
         percent: intensity);
   }
 
-  static Color gradientShaderWhiteColor({@required double intensity}) {
+  static Color gradientShaderWhiteColor({required double intensity}) {
     // intensity act on opacity;
     return _applyPercentageOnOpacity(
         maxColor: NeumorphicColors._gradientShaderWhiteColor,
@@ -84,7 +84,7 @@ class NeumorphicColors {
   }
 
   static Color _applyPercentageOnOpacity(
-      {@required Color maxColor, @required double percent}) {
+      {required Color maxColor, required double percent}) {
     final maxOpacity = maxColor.opacity;
     final maxIntensity = Neumorphic.MAX_INTENSITY;
     final newOpacity = percent * maxOpacity / maxIntensity;

--- a/lib/src/decoration/cache/abstract_neumorphic_painter_cache.dart
+++ b/lib/src/decoration/cache/abstract_neumorphic_painter_cache.dart
@@ -4,23 +4,21 @@ import 'dart:ui';
 import '../../../flutter_neumorphic.dart';
 
 abstract class AbstractNeumorphicEmbossPainterCache {
-  bool get isEmpty => _cacheOffset == null;
-
-  Offset _cacheOffset;
+  late Offset _cacheOffset;
   Offset get originOffset => _cacheOffset;
 
-  double _cacheWidth;
+  late double _cacheWidth;
   double get width => _cacheWidth;
-  double _cacheHeight;
+  late double _cacheHeight;
   double get height => _cacheHeight;
-  double _cacheRadius;
+  late double _cacheRadius;
 
-  Rect _layerRect;
+  late Rect _layerRect;
   Rect get layerRect => _layerRect;
 
   AbstractNeumorphicEmbossPainterCache();
 
-  bool updateSize({Offset newOffset, Size newSize}) {
+  bool updateSize({required Offset newOffset, required Size newSize}) {
     if (this._cacheOffset != newOffset ||
         this._cacheWidth != newSize.width ||
         this._cacheHeight != newSize.height) {
@@ -41,10 +39,10 @@ abstract class AbstractNeumorphicEmbossPainterCache {
     return false;
   }
 
-  Rect updateLayerRect({Offset newOffset, Size newSize});
+  Rect updateLayerRect({required Offset newOffset, required Size newSize});
 
-  double _cacheStyleDepth; //old style depth
-  double _depth; //depth used to draw
+  late double _cacheStyleDepth; //old style depth
+  late double _depth; //depth used to draw
   double get depth => _depth; //depth used to draw
   bool updateStyleDepth(double newStyleDepth, double radiusFactor) {
     if (_cacheStyleDepth != newStyleDepth) {
@@ -59,13 +57,13 @@ abstract class AbstractNeumorphicEmbossPainterCache {
     return false;
   }
 
-  Offset _depthOffset;
+  late Offset _depthOffset;
   Offset get depthOffset => _depthOffset;
   void updateDepthOffset() {
     _depthOffset = this.lightSource.offset.scale(_depth, _depth);
   }
 
-  Color _cacheColor;
+  late Color _cacheColor;
   Color get backgroundColor => _cacheColor;
   bool updateStyleColor(Color newColor) {
     if (_cacheColor != newColor) {
@@ -76,11 +74,11 @@ abstract class AbstractNeumorphicEmbossPainterCache {
     return false;
   }
 
-  bool
+  late bool
       _cacheOppositeShadowLightSource; //store the old style lightsource property
-  LightSource _cacheLightSource; //store the old style lightsource
+  late LightSource _cacheLightSource; //store the old style lightsource
 
-  LightSource _lightSource; //used to draw
+  late LightSource _lightSource; //used to draw
   LightSource get lightSource => _lightSource; //used to draw
   bool updateLightSource(
       LightSource newLightSource, bool newOppositeShadowLightSource) {
@@ -109,28 +107,28 @@ abstract class AbstractNeumorphicEmbossPainterCache {
     return false;
   }
 
-  MaskFilter _maskFilterBlur;
+  late MaskFilter _maskFilterBlur;
   MaskFilter get maskFilterBlur => _maskFilterBlur;
-  void _updateMaskFilter({double newDepth}) {
+  void _updateMaskFilter({required double newDepth}) {
     this._maskFilterBlur = MaskFilter.blur(BlurStyle.normal, newDepth);
   }
 
-  double _styleIntensity;
-  Color _styleShadowLightColor;
-  Color _shadowLightColor;
+  late double _styleIntensity;
+  late Color _styleShadowLightColor;
+  late Color _shadowLightColor;
   Color get shadowLightColor => _shadowLightColor;
-  Color _styleShadowDarkColor;
-  Color _shadowDarkColor;
+  late Color _styleShadowDarkColor;
+  late Color _shadowDarkColor;
   Color get shadowDarkColor => _shadowDarkColor;
 
-  Color generateShadowLightColor({Color color, double intensity});
+  Color generateShadowLightColor({required Color color, required double intensity});
 
-  Color generateShadowDarkColor({Color color, double intensity});
+  Color generateShadowDarkColor({required Color color, required double intensity});
 
   bool updateShadowColor({
-    Color newShadowLightColorEmboss,
-    Color newShadowDarkColorEmboss,
-    double newIntensity,
+    required Color newShadowLightColorEmboss,
+    required Color newShadowDarkColorEmboss,
+    required double newIntensity,
   }) {
     bool invalidateIntensity = false;
     bool invalidate = false;
@@ -164,9 +162,9 @@ abstract class AbstractNeumorphicEmbossPainterCache {
   void updateTranslations();
 
   final List<Path> subPaths = [];
-  Path _path;
+  late Path _path;
   Path get path => _path;
-  void updatePath({Path newPath}) {
+  void updatePath({required Path newPath}) {
     this._path = newPath;
     subPaths.clear();
     var pathMetrics = newPath.computeMetrics();

--- a/lib/src/decoration/cache/neumorphic_emboss_painter_cache.dart
+++ b/lib/src/decoration/cache/neumorphic_emboss_painter_cache.dart
@@ -6,7 +6,7 @@ import 'abstract_neumorphic_painter_cache.dart';
 class NeumorphicEmbossPainterCache
     extends AbstractNeumorphicEmbossPainterCache {
   @override
-  Color generateShadowDarkColor({Color color, double intensity}) {
+  Color generateShadowDarkColor({required Color color, required double intensity}) {
     return NeumorphicColors.embossDarkColor(
       color,
       intensity: intensity,
@@ -14,32 +14,32 @@ class NeumorphicEmbossPainterCache
   }
 
   @override
-  Color generateShadowLightColor({Color color, double intensity}) {
+  Color generateShadowLightColor({required Color color, required double intensity}) {
     return NeumorphicColors.embossWhiteColor(
       color,
       intensity: intensity,
     );
   }
 
-  Rect updateLayerRect({Offset newOffset, Size newSize}) {
+  Rect updateLayerRect({required Offset newOffset, required Size newSize}) {
     return newOffset & newSize;
   }
 
   NeumorphicEmbossPainterCache() : super();
 
-  double xDepth;
-  double yDepth;
-  double xPadding;
-  double yPadding;
-  double blackShadowLeftTranslation;
-  double blackShadowTopTranslation;
-  double witheShadowLeftTranslation;
-  double witheShadowTopTranslation;
-  double scaledWidth;
-  double scaledHeight;
+  late double xDepth;
+  late double yDepth;
+  late double xPadding;
+  late double yPadding;
+  late double blackShadowLeftTranslation;
+  late double blackShadowTopTranslation;
+  late double witheShadowLeftTranslation;
+  late double witheShadowTopTranslation;
+  late double scaledWidth;
+  late double scaledHeight;
 
-  double scaleX;
-  double scaleY;
+  late double scaleX;
+  late double scaleY;
 
   //call after _cacheWidth & _cacheHeight set
   @override

--- a/lib/src/decoration/cache/neumorphic_painter_cache.dart
+++ b/lib/src/decoration/cache/neumorphic_painter_cache.dart
@@ -5,12 +5,12 @@ import 'abstract_neumorphic_painter_cache.dart';
 
 class NeumorphicPainterCache extends AbstractNeumorphicEmbossPainterCache {
   @override
-  Color generateShadowDarkColor({Color color, double intensity}) {
+  Color generateShadowDarkColor({required Color color, required double intensity}) {
     return NeumorphicColors.decorationDarkColor(color, intensity: intensity);
   }
 
   @override
-  Color generateShadowLightColor({Color color, double intensity}) {
+  Color generateShadowLightColor({required Color color, required double intensity}) {
     return NeumorphicColors.decorationWhiteColor(color, intensity: intensity);
   }
 
@@ -20,7 +20,7 @@ class NeumorphicPainterCache extends AbstractNeumorphicEmbossPainterCache {
   }
 
   @override
-  Rect updateLayerRect({Offset newOffset, Size newSize}) {
+  Rect updateLayerRect({required Offset newOffset, required Size newSize}) {
     return Rect.fromLTRB(
       originOffset.dx - newSize.width,
       originOffset.dy - newSize.height,

--- a/lib/src/decoration/neumorphic_box_decoration_helper.dart
+++ b/lib/src/decoration/neumorphic_box_decoration_helper.dart
@@ -3,8 +3,8 @@ import 'package:flutter/widgets.dart';
 import '../theme/theme.dart';
 
 Shader getGradientShader(
-    {@required Rect gradientRect,
-    @required LightSource source,
+    {required Rect gradientRect,
+    required LightSource source,
     double intensity = 0.25}) {
   var sourceInvert = source.invert();
 

--- a/lib/src/decoration/neumorphic_decorations.dart
+++ b/lib/src/decoration/neumorphic_decorations.dart
@@ -15,17 +15,17 @@ class NeumorphicDecoration extends Decoration {
   final bool isForeground;
 
   NeumorphicDecoration({
-    @required this.style,
-    @required this.isForeground,
-    @required this.renderingByPath,
-    @required this.splitBackgroundForeground,
-    @required this.shape,
+    required this.style,
+    required this.isForeground,
+    required this.renderingByPath,
+    required this.splitBackgroundForeground,
+    required this.shape,
   });
 
   @override
-  BoxPainter createBoxPainter([onChanged]) {
+  BoxPainter createBoxPainter([VoidCallback? onChanged]) {
     //print("createBoxPainter : ${style.depth}");
-    if (style.depth >= 0) {
+    if (style.depth != null && style.depth! >= 0) {
       return NeumorphicDecorationPainter(
         style: style,
         drawGradient: (isForeground && splitBackgroundForeground) ||
@@ -35,7 +35,7 @@ class NeumorphicDecoration extends Decoration {
         drawShadow: !isForeground,
         //only box draw shadow
         renderingByPath: this.renderingByPath,
-        onChanged: onChanged,
+        onChanged: onChanged ?? (){},
         shape: shape,
       );
     } else {
@@ -44,23 +44,23 @@ class NeumorphicDecoration extends Decoration {
         style: style,
         drawShadow: (isForeground && splitBackgroundForeground) ||
             (!isForeground && !splitBackgroundForeground),
-        onChanged: onChanged,
+        onChanged: onChanged ?? (){},
         shape: shape,
       );
     }
   }
 
   @override
-  NeumorphicDecoration lerpFrom(Decoration a, double t) {
+  NeumorphicDecoration lerpFrom(Decoration? a, double t) {
     if (a == null) return scale(t);
-    if (a is NeumorphicDecoration) return NeumorphicDecoration.lerp(a, this, t);
+    if (a is NeumorphicDecoration) return NeumorphicDecoration.lerp(a, this, t)!;
     return super.lerpFrom(a, t) as NeumorphicDecoration;
   }
 
   @override
-  NeumorphicDecoration lerpTo(Decoration b, double t) {
+  NeumorphicDecoration lerpTo(Decoration? b, double t) {
     if (b == null) return scale(1.0 - t);
-    if (b is NeumorphicDecoration) return NeumorphicDecoration.lerp(this, b, t);
+    if (b is NeumorphicDecoration) return NeumorphicDecoration.lerp(this, b, t)!;
     return super.lerpTo(b, t) as NeumorphicDecoration;
   }
 
@@ -70,18 +70,16 @@ class NeumorphicDecoration extends Decoration {
         isForeground: this.isForeground,
         renderingByPath: this.renderingByPath,
         splitBackgroundForeground: this.splitBackgroundForeground,
-        shape: NeumorphicBoxShape.lerp(null, shape, factor),
+        shape: NeumorphicBoxShape.lerp(null, shape, factor)!,
         style: style.copyWith());
   }
 
-  static NeumorphicDecoration lerp(
-      NeumorphicDecoration a, NeumorphicDecoration b, double t) {
-    assert(t != null);
-
+  static NeumorphicDecoration? lerp(
+      NeumorphicDecoration? a, NeumorphicDecoration? b, double t) {
     //print("lerp $t ${a.style.depth}, ${b.style.depth}");
 
     if (a == null && b == null) return null;
-    if (a == null) return b.scale(t);
+    if (a == null) return b!.scale(t);
     if (b == null) return a.scale(1.0 - t);
     if (t == 0.0) {
       //print("return a");
@@ -97,7 +95,7 @@ class NeumorphicDecoration extends Decoration {
 
     return NeumorphicDecoration(
         isForeground: a.isForeground,
-        shape: NeumorphicBoxShape.lerp(a.shape, b.shape, t),
+        shape: NeumorphicBoxShape.lerp(a.shape, b.shape, t)!,
         splitBackgroundForeground: a.splitBackgroundForeground,
         renderingByPath: a.renderingByPath,
         style: a.style.copyWith(

--- a/lib/src/decoration/neumorphic_emboss_decoration_painter.dart
+++ b/lib/src/decoration/neumorphic_emboss_decoration_painter.dart
@@ -16,24 +16,27 @@ class NeumorphicEmbossDecorationPainter extends BoxPainter {
   final NeumorphicStyle style;
   final NeumorphicBoxShape shape;
 
-  Paint _backgroundPaint;
-  Paint _whiteShadowPaint;
-  Paint _whiteShadowMaskPaint;
-  Paint _blackShadowPaint;
-  Paint _blackShadowMaskPaint;
-  Paint _borderPaint;
+  late Paint _backgroundPaint;
+  late Paint _whiteShadowPaint;
+  late Paint _whiteShadowMaskPaint;
+  late Paint _blackShadowPaint;
+  late Paint _blackShadowMaskPaint;
+  late Paint _borderPaint;
 
   final bool drawShadow;
   final bool drawBackground;
 
   NeumorphicEmbossDecorationPainter(
-      {@required this.style,
-      @required NeumorphicBoxShape shape,
-      @required this.drawBackground,
-      @required this.drawShadow,
-      @required VoidCallback onChanged})
+      {required this.style,
+      required this.drawBackground,
+      required this.drawShadow,
+      required VoidCallback onChanged,
+      NeumorphicBoxShape? shape})
       : this.shape = shape ?? NeumorphicBoxShape.rect(),
-        super(onChanged);
+        _cache = NeumorphicEmbossPainterCache(),
+        super(onChanged) {
+    _generatePainters();
+  }
 
   void _generatePainters() {
     this._backgroundPaint = Paint();
@@ -49,39 +52,45 @@ class NeumorphicEmbossDecorationPainter extends BoxPainter {
   }
 
   void _updateCache(
-      {Offset offset,
-      ImageConfiguration configuration,
-      NeumorphicStyle newStyle}) {
-    if (_cache == null) {
-      _cache = NeumorphicEmbossPainterCache();
-      _generatePainters();
+      {required Offset offset,
+      required ImageConfiguration configuration,
+      required NeumorphicStyle newStyle}) {
+    bool invalidateSize = false;
+    if (configuration.size != null) {
+      invalidateSize =
+          this._cache.updateSize(newOffset: offset, newSize: configuration.size!);
+      if (invalidateSize) {
+        _cache.updatePath(
+            newPath: shape.customShapePathProvider.getPath(configuration.size!));
+      }
     }
 
-    final bool invalidateSize =
-        this._cache.updateSize(newOffset: offset, newSize: configuration.size);
-    if (invalidateSize) {
-      _cache.updatePath(
-          newPath: shape.customShapePathProvider.getPath(configuration.size));
-    }
-
-    final bool invalidateLightSource = this
+    bool invalidateLightSource = false;
+    invalidateLightSource = this
         ._cache
-        .updateLightSource(style.lightSource, style.oppositeShadowLightSource);
-    final bool invalidateColor = this._cache.updateStyleColor(style.color);
-    if (invalidateColor) {
-      _backgroundPaint..color = _cache.backgroundColor;
-    }
+        .updateLightSource(
+        style.lightSource, style.oppositeShadowLightSource);
 
-    final bool invalidateDepth = this._cache.updateStyleDepth(style.depth, 5);
-    if (invalidateDepth) {
-      _blackShadowMaskPaint..maskFilter = _cache.maskFilterBlur;
-      _whiteShadowMaskPaint..maskFilter = _cache.maskFilterBlur;
+    bool invalidateColor = false;
+    if (style.color != null) {
+      invalidateColor = this._cache.updateStyleColor(style.color!);
+      if (invalidateColor) {
+        _backgroundPaint..color = _cache.backgroundColor;
+      }
+    }
+    bool invalidateDepth = false;
+    if (style.depth != null) {
+      invalidateDepth = this._cache.updateStyleDepth(style.depth!, 5);
+      if (invalidateDepth) {
+        _blackShadowMaskPaint..maskFilter = _cache.maskFilterBlur;
+        _whiteShadowMaskPaint..maskFilter = _cache.maskFilterBlur;
+      }
     }
 
     final bool invalidateShadowColors = this._cache.updateShadowColor(
-          newShadowLightColorEmboss: style.shadowLightColorEmboss,
-          newShadowDarkColorEmboss: style.shadowDarkColorEmboss,
-          newIntensity: style.intensity,
+          newShadowLightColorEmboss: style.shadowLightColorEmboss ?? Color(0xFFFFFFFF),
+          newShadowDarkColorEmboss: style.shadowDarkColorEmboss ?? Color(0xFF000000),
+          newIntensity: style.intensity ?? 0.25,
         );
     if (invalidateShadowColors) {
       _whiteShadowPaint..color = _cache.shadowLightColor;
@@ -101,8 +110,8 @@ class NeumorphicEmbossDecorationPainter extends BoxPainter {
       ..restore();
   }
 
-  void _drawBorder({Canvas canvas, Offset offset, Path path}) {
-    if (style.border.width > 0) {
+  void _drawBorder({required Canvas canvas, required Offset offset, required Path path}) {
+    if (style.border.width != null && style.border.width! > 0) {
       canvas
         ..save()
         ..translate(offset.dx, offset.dy)
@@ -147,7 +156,7 @@ class NeumorphicEmbossDecorationPainter extends BoxPainter {
         _paintBackground(canvas, subPath);
       }
 
-      if (style.border != null && style.border.isEnabled) {
+      if (style.border.isEnabled) {
         _drawBorder(canvas: canvas, offset: offset, path: subPath);
       }
 

--- a/lib/src/decoration/neumorphic_text_decorations.dart
+++ b/lib/src/decoration/neumorphic_text_decorations.dart
@@ -15,18 +15,18 @@ class NeumorphicTextDecoration extends Decoration {
   final TextAlign textAlign;
 
   NeumorphicTextDecoration({
-    @required this.style,
-    @required this.textStyle,
-    @required this.isForeground,
-    @required this.renderingByPath,
-    @required this.text,
-    @required this.textAlign,
+    required this.style,
+    required this.textStyle,
+    required this.isForeground,
+    required this.renderingByPath,
+    required this.text,
+    required this.textAlign,
   });
 
   @override
-  BoxPainter createBoxPainter([onChanged]) {
+  BoxPainter createBoxPainter([VoidCallback? onChanged]) {
     //print("createBoxPainter : ${style.depth}");
-    if (style.depth >= 0) {
+    if (style.depth != null && style.depth! >= 0) {
       return NeumorphicDecorationTextPainter(
         style: style,
         textStyle: textStyle,
@@ -37,11 +37,11 @@ class NeumorphicTextDecoration extends Decoration {
         drawShadow: !isForeground,
         //only box draw shadow
         renderingByPath: this.renderingByPath,
-        onChanged: onChanged,
+        onChanged: onChanged ?? (){},
         text: text,
       );
     } else {
-      return NeumorphicEmptyTextPainter(onChanged: onChanged);
+      return NeumorphicEmptyTextPainter(onChanged: onChanged ?? (){});
     }
     /* else {
       return NeumorphicEmbossDecorationPainter(
@@ -57,7 +57,7 @@ class NeumorphicTextDecoration extends Decoration {
   }
 
   @override
-  NeumorphicTextDecoration lerpFrom(Decoration a, double t) {
+  NeumorphicTextDecoration? lerpFrom(Decoration? a, double t) {
     if (a == null) return scale(t);
     if (a is NeumorphicTextDecoration)
       return NeumorphicTextDecoration.lerp(a, this, t);
@@ -65,7 +65,7 @@ class NeumorphicTextDecoration extends Decoration {
   }
 
   @override
-  NeumorphicTextDecoration lerpTo(Decoration b, double t) {
+  NeumorphicTextDecoration? lerpTo(Decoration? b, double t) {
     if (b == null) return scale(1.0 - t);
     if (b is NeumorphicTextDecoration)
       return NeumorphicTextDecoration.lerp(this, b, t);
@@ -83,14 +83,12 @@ class NeumorphicTextDecoration extends Decoration {
         style: style.copyWith());
   }
 
-  static NeumorphicTextDecoration lerp(
-      NeumorphicTextDecoration a, NeumorphicTextDecoration b, double t) {
-    assert(t != null);
-
+  static NeumorphicTextDecoration? lerp(
+      NeumorphicTextDecoration? a, NeumorphicTextDecoration? b, double t) {
     //print("lerp $t ${a.style.depth}, ${b.style.depth}");
 
     if (a == null && b == null) return null;
-    if (a == null) return b.scale(t);
+    if (a == null) return b!.scale(t);
     if (b == null) return a.scale(1.0 - t);
     if (t == 0.0) {
       //print("return a");
@@ -108,7 +106,7 @@ class NeumorphicTextDecoration extends Decoration {
         isForeground: a.isForeground,
         text: a.text,
         textAlign: a.textAlign,
-        textStyle: TextStyle.lerp(a.textStyle, b.textStyle, t),
+        textStyle: TextStyle.lerp(a.textStyle, b.textStyle, t) ?? TextStyle(),
         renderingByPath: a.renderingByPath,
         style: a.style.copyWith(
           border: NeumorphicBorder.lerp(aStyle.border, bStyle.border, t),

--- a/lib/src/light_source.dart
+++ b/lib/src/light_source.dart
@@ -47,8 +47,7 @@ class LightSource {
 
   LightSource invert() => LightSource(dx * -1, dy * -1);
 
-  static LightSource lerp(LightSource a, LightSource b, double t) {
-    assert(t != null);
+  static LightSource? lerp(LightSource? a, LightSource? b, double t) {
 
     if (a == null && b == null) return null;
     if (a == null) return b;
@@ -58,14 +57,14 @@ class LightSource {
     if (t == 1.0) return b;
 
     return LightSource(
-      a.dx != b.dx ? lerpDouble(a.dx, b.dx, t) : a.dx,
-      a.dy != b.dy ? lerpDouble(a.dy, b.dy, t) : a.dy,
+      (a.dx != b.dx ? lerpDouble(a.dx, b.dx, t) : a.dx)!,
+      (a.dy != b.dy ? lerpDouble(a.dy, b.dy, t) : a.dy)!,
     );
   }
 
   LightSource copyWith({
-    double dx,
-    double dy,
+    double? dx,
+    double? dy,
   }) {
     return LightSource(
       dx ?? this.dx,

--- a/lib/src/neumorphic_box_shape.dart
+++ b/lib/src/neumorphic_box_shape.dart
@@ -49,9 +49,8 @@ class NeumorphicBoxShape {
   bool get isBeveled =>
       customShapePathProvider.runtimeType == BeveledPathProvider;
 
-  static NeumorphicBoxShape lerp(
-      NeumorphicBoxShape a, NeumorphicBoxShape b, double t) {
-    assert(t != null);
+  static NeumorphicBoxShape? lerp(
+      NeumorphicBoxShape? a, NeumorphicBoxShape? b, double t) {
 
     if (a == null && b == null) return null;
 
@@ -59,14 +58,14 @@ class NeumorphicBoxShape {
     if (t == 1.0) return b;
 
     if (a == null) {
-      if (b.isCircle || b.isRect || b.isStadium || b.isCustomPath) {
+      if (b!.isCircle || b.isRect || b.isStadium || b.isCustomPath) {
         return b;
       } else {
         return NeumorphicBoxShape.roundRect(BorderRadius.lerp(
           null,
           (b.customShapePathProvider as RRectPathProvider).borderRadius,
           t,
-        ));
+        )!);
       }
     }
     if (a.isCircle || a.isRect || a.isStadium || a.isCustomPath) {
@@ -81,7 +80,7 @@ class NeumorphicBoxShape {
           null,
           (a.customShapePathProvider as RRectPathProvider).borderRadius,
           t,
-        ));
+        )!);
       }
     }
     if (b.isCircle || b.isRect || b.isStadium || b.isCustomPath) {
@@ -93,13 +92,13 @@ class NeumorphicBoxShape {
         (a.customShapePathProvider as BeveledPathProvider).borderRadius,
         (b.customShapePathProvider as BeveledPathProvider).borderRadius,
         t,
-      ));
+      )!);
     }
 
     return NeumorphicBoxShape.roundRect(BorderRadius.lerp(
       (a.customShapePathProvider as RRectPathProvider).borderRadius,
       (b.customShapePathProvider as RRectPathProvider).borderRadius,
       t,
-    ));
+    )!);
   }
 }

--- a/lib/src/shape/beveled_path_provider.dart
+++ b/lib/src/shape/beveled_path_provider.dart
@@ -5,7 +5,7 @@ import 'dart:math' as math;
 class BeveledPathProvider extends NeumorphicPathProvider {
   final BorderRadius borderRadius;
 
-  const BeveledPathProvider(this.borderRadius, {Listenable reclip});
+  const BeveledPathProvider(this.borderRadius, {Listenable? reclip});
 
   @override
   bool shouldReclip(NeumorphicPathProvider oldClipper) {

--- a/lib/src/shape/circle_path_provider.dart
+++ b/lib/src/shape/circle_path_provider.dart
@@ -4,7 +4,7 @@ import '../../flutter_neumorphic.dart';
 import 'neumorphic_path_provider.dart';
 
 class CirclePathProvider extends NeumorphicPathProvider {
-  const CirclePathProvider({Listenable reclip});
+  const CirclePathProvider({Listenable? reclip});
 
   @override
   bool shouldReclip(NeumorphicPathProvider oldClipper) {

--- a/lib/src/shape/neumorphic_path_provider.dart
+++ b/lib/src/shape/neumorphic_path_provider.dart
@@ -1,7 +1,7 @@
 import '../../flutter_neumorphic.dart';
 
 abstract class NeumorphicPathProvider extends CustomClipper<Path> {
-  const NeumorphicPathProvider({Listenable reclip}) : super(reclip: reclip);
+  const NeumorphicPathProvider({Listenable? reclip}) : super(reclip: reclip);
 
   @override
   Path getClip(Size size) {

--- a/lib/src/shape/rect_path_provider.dart
+++ b/lib/src/shape/rect_path_provider.dart
@@ -2,7 +2,7 @@ import '../../flutter_neumorphic.dart';
 import 'neumorphic_path_provider.dart';
 
 class RectPathProvider extends NeumorphicPathProvider {
-  const RectPathProvider({Listenable reclip});
+  const RectPathProvider({Listenable? reclip});
 
   @override
   bool shouldReclip(NeumorphicPathProvider oldClipper) {

--- a/lib/src/shape/rrect_path_provider.dart
+++ b/lib/src/shape/rrect_path_provider.dart
@@ -4,7 +4,7 @@ import 'neumorphic_path_provider.dart';
 class RRectPathProvider extends NeumorphicPathProvider {
   final BorderRadius borderRadius;
 
-  const RRectPathProvider(this.borderRadius, {Listenable reclip});
+  const RRectPathProvider(this.borderRadius, {Listenable? reclip});
 
   @override
   bool shouldReclip(NeumorphicPathProvider oldClipper) {

--- a/lib/src/shape/stadium_path_provider.dart
+++ b/lib/src/shape/stadium_path_provider.dart
@@ -2,7 +2,7 @@ import '../../flutter_neumorphic.dart';
 import 'rrect_path_provider.dart';
 
 class StadiumPathProvider extends RRectPathProvider {
-  const StadiumPathProvider({Listenable reclip})
+  const StadiumPathProvider({Listenable? reclip})
       : super(
             const BorderRadius.all(
               const Radius.circular(1000),

--- a/lib/src/theme/app_bar.dart
+++ b/lib/src/theme/app_bar.dart
@@ -8,11 +8,11 @@ import 'package:flutter_neumorphic/flutter_neumorphic.dart';
 @immutable
 class NeumorphicAppBarThemeData {
   final Color color;
-  final IconThemeData iconTheme;
+  final IconThemeData? iconTheme;
   final NeumorphicStyle buttonStyle;
   final EdgeInsets buttonPadding;
-  final bool centerTitle;
-  final TextStyle textStyle;
+  final bool? centerTitle;
+  final TextStyle? textStyle;
   final NeumorphicAppBarIcons icons;
 
   const NeumorphicAppBarThemeData({
@@ -29,14 +29,14 @@ class NeumorphicAppBarThemeData {
 class NeumorphicAppBarIcons {
   final Icon closeIcon;
   final Icon menuIcon;
-  final Icon _backIcon;
-  final Icon _forwardIcon;
+  final Icon? _backIcon;
+  final Icon? _forwardIcon;
 
   const NeumorphicAppBarIcons({
     this.menuIcon = const Icon(Icons.menu),
     this.closeIcon = const Icon(Icons.close),
-    Icon backIcon,
-    Icon forwardIcon,
+    Icon? backIcon,
+    Icon? forwardIcon,
   })  : _backIcon = backIcon,
         _forwardIcon = forwardIcon;
 
@@ -52,10 +52,10 @@ class NeumorphicAppBarIcons {
       : const Icon(Icons.arrow_forward);
 
   NeumorphicAppBarIcons copyWith({
-    Icon backIcon,
-    Icon closeIcon,
-    Icon menuIcon,
-    Icon forwardIcon,
+    Icon? backIcon,
+    Icon? closeIcon,
+    Icon? menuIcon,
+    Icon? forwardIcon,
   }) {
     return NeumorphicAppBarIcons(
       backIcon: backIcon ?? this.backIcon,

--- a/lib/src/theme/inherited_neumorphic_theme.dart
+++ b/lib/src/theme/inherited_neumorphic_theme.dart
@@ -9,7 +9,7 @@ export 'theme.dart';
 export 'theme_wrapper.dart';
 
 typedef NeumorphicThemeUpdater = NeumorphicThemeData Function(
-    NeumorphicThemeData current);
+    NeumorphicThemeData? current);
 
 class NeumorphicThemeInherited extends InheritedWidget {
   final Widget child;
@@ -17,15 +17,15 @@ class NeumorphicThemeInherited extends InheritedWidget {
   final ValueChanged<ThemeWrapper> onChanged;
 
   NeumorphicThemeInherited(
-      {Key key,
-      @required this.child,
-      @required this.value,
-      @required this.onChanged});
+      {Key? key,
+      required this.child,
+      required this.value,
+      required this.onChanged}) : super(key: key, child: child);
 
   @override
   bool updateShouldNotify(NeumorphicThemeInherited old) => value != old.value;
 
-  NeumorphicThemeData get current {
+  NeumorphicThemeData? get current {
     return this.value.current;
   }
 

--- a/lib/src/theme/neumorphic_theme.dart
+++ b/lib/src/theme/neumorphic_theme.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
 
+import '../../flutter_neumorphic.dart';
 import 'inherited_neumorphic_theme.dart';
 import 'theme.dart';
 import 'theme_wrapper.dart';
@@ -49,17 +50,17 @@ class NeumorphicTheme extends StatefulWidget {
   final ThemeMode themeMode;
 
   NeumorphicTheme({
-    Key key,
-    @required this.child,
+    Key? key,
+    required this.child,
     this.theme = neumorphicDefaultTheme,
     this.darkTheme = neumorphicDefaultDarkTheme,
-    this.themeMode,
+    this.themeMode = ThemeMode.system,
   });
 
   @override
   _NeumorphicThemeState createState() => _NeumorphicThemeState();
 
-  static NeumorphicThemeInherited of(BuildContext context) {
+  static NeumorphicThemeInherited? of(BuildContext context) {
     try {
       return context
           .dependOnInheritedWidgetOfExactType<NeumorphicThemeInherited>();
@@ -69,11 +70,15 @@ class NeumorphicTheme extends StatefulWidget {
   }
 
   static void update(BuildContext context, NeumorphicThemeUpdater updater) {
-    return of(context).update(updater);
+    final theme = of(context);
+    if (theme == null) return;
+    return theme.update(updater);
   }
 
   static bool isUsingDark(BuildContext context) {
-    return of(context).isUsingDark;
+    final theme = of(context);
+    if (theme == null) return false;
+    return theme.isUsingDark;
   }
 
   static Color accentColor(BuildContext context) {
@@ -92,16 +97,16 @@ class NeumorphicTheme extends StatefulWidget {
     return currentTheme(context).disabledColor;
   }
 
-  static double intensity(BuildContext context) {
+  static double? intensity(BuildContext context) {
     return currentTheme(context).intensity;
   }
 
-  static double depth(BuildContext context) {
+  static double? depth(BuildContext context) {
     return currentTheme(context).depth;
   }
 
-  static double embossDepth(BuildContext context) {
-    return -(currentTheme(context).depth.abs());
+  static double? embossDepth(BuildContext context) {
+    return -(currentTheme(context).depth?.abs())!;
   }
 
   static Color defaultTextColor(BuildContext context) {
@@ -109,28 +114,25 @@ class NeumorphicTheme extends StatefulWidget {
   }
 
   static NeumorphicThemeData currentTheme(BuildContext context) {
-    try {
-      final provider = NeumorphicTheme.of(context);
-      return provider.current;
-    } catch (t) {
-      return neumorphicDefaultTheme;
-    }
+    final provider = NeumorphicTheme.of(context);
+    if (provider == null) return neumorphicDefaultTheme;
+    return provider.current == null ? neumorphicDefaultTheme : provider.current!;
   }
 }
 
 double applyThemeDepthEnable(
-    {@required BuildContext context,
-    @required bool styleEnableDepth,
-    @required double depth}) {
+    {required BuildContext context,
+    required bool styleEnableDepth,
+    required double depth}) {
   final NeumorphicThemeData theme = NeumorphicTheme.currentTheme(context);
   return wrapDepthWithThemeData(
       themeData: theme, styleEnableDepth: styleEnableDepth, depth: depth);
 }
 
 double wrapDepthWithThemeData(
-    {@required NeumorphicThemeData themeData,
-    @required bool styleEnableDepth,
-    @required double depth}) {
+    {required NeumorphicThemeData themeData,
+    required bool styleEnableDepth,
+    required double depth}) {
   if (themeData.disableDepth) {
     return 0;
   } else {
@@ -139,7 +141,7 @@ double wrapDepthWithThemeData(
 }
 
 class _NeumorphicThemeState extends State<NeumorphicTheme> {
-  ThemeWrapper _themeHost;
+  late ThemeWrapper _themeHost;
 
   @override
   void initState() {

--- a/lib/src/theme/neumorphic_theme.dart
+++ b/lib/src/theme/neumorphic_theme.dart
@@ -106,7 +106,8 @@ class NeumorphicTheme extends StatefulWidget {
   }
 
   static double? embossDepth(BuildContext context) {
-    return -(currentTheme(context).depth?.abs())!;
+    if (currentTheme(context).depth == null) return null;
+    return -currentTheme(context).depth!.abs();
   }
 
   static Color defaultTextColor(BuildContext context) {

--- a/lib/src/theme/theme.dart
+++ b/lib/src/theme/theme.dart
@@ -1,7 +1,7 @@
 import 'dart:ui';
 
 import 'package:flutter/foundation.dart';
-import 'package:flutter/material.dart' show IconTheme, IconThemeData, TextTheme;
+import 'package:flutter/material.dart' show IconThemeData, TextTheme;
 import 'package:flutter/painting.dart';
 import 'package:flutter_neumorphic/src/theme/app_bar.dart';
 import 'package:flutter_neumorphic/src/widget/container.dart';
@@ -53,7 +53,7 @@ class NeumorphicThemeData {
   final Color shadowLightColorEmboss;
   final Color shadowDarkColorEmboss;
 
-  final NeumorphicBoxShape _boxShape;
+  final NeumorphicBoxShape? _boxShape;
   NeumorphicBoxShape get boxShape =>
       _boxShape ?? NeumorphicBoxShape.roundRect(BorderRadius.circular(8));
   final Color borderColor;
@@ -69,23 +69,23 @@ class NeumorphicThemeData {
   final TextTheme textTheme;
 
   /// Default button style to use and apply across the app
-  final NeumorphicStyle buttonStyle;
+  final NeumorphicStyle? buttonStyle;
 
   /// Default icon theme to use and apply across the app
   final IconThemeData iconTheme;
   final NeumorphicAppBarThemeData appBarTheme;
 
   /// Get this theme's depth, clamp to min/max neumorphic constants
-  double get depth => _depth?.clamp(Neumorphic.MIN_DEPTH, Neumorphic.MAX_DEPTH);
+  double? get depth => _depth.clamp(Neumorphic.MIN_DEPTH, Neumorphic.MAX_DEPTH);
 
   /// Get this theme's intensity, clamp to min/max neumorphic constants
-  double get intensity =>
-      _intensity?.clamp(Neumorphic.MIN_INTENSITY, Neumorphic.MAX_INTENSITY);
+  double? get intensity =>
+      _intensity.clamp(Neumorphic.MIN_INTENSITY, Neumorphic.MAX_INTENSITY);
 
   const NeumorphicThemeData({
     this.baseColor = _defaultBaseColor,
     double depth = _defaultDepth,
-    NeumorphicBoxShape boxShape,
+    NeumorphicBoxShape? boxShape,
     double intensity = _defaultIntensity,
     this.accentColor = _defaultAccent,
     this.variantColor = _defaultVariant,
@@ -110,7 +110,7 @@ class NeumorphicThemeData {
   const NeumorphicThemeData.dark({
     this.baseColor = NeumorphicColors.darkBackground,
     double depth = _defaultDepth,
-    NeumorphicBoxShape boxShape,
+    NeumorphicBoxShape? boxShape,
     double intensity = _defaultIntensity,
     this.accentColor = _defaultAccent,
     this.textTheme = const TextTheme(),
@@ -189,27 +189,27 @@ class NeumorphicThemeData {
   /// Create a copy of this theme
   /// With possibly new values given from this method's arguments
   NeumorphicThemeData copyWith({
-    Color baseColor,
-    Color accentColor,
-    Color variantColor,
-    Color disabledColor,
-    Color shadowLightColor,
-    Color shadowDarkColor,
-    Color shadowLightColorEmboss,
-    Color shadowDarkColorEmboss,
-    Color defaultTextColor,
-    NeumorphicBoxShape boxShape,
-    TextTheme textTheme,
-    NeumorphicStyle buttonStyle,
-    IconThemeData iconTheme,
-    NeumorphicAppBarThemeData appBarTheme,
-    NeumorphicStyle defaultStyle,
-    bool disableDepth,
-    double depth,
-    double intensity,
-    Color borderColor,
-    double borderSize,
-    LightSource lightSource,
+    Color? baseColor,
+    Color? accentColor,
+    Color? variantColor,
+    Color? disabledColor,
+    Color? shadowLightColor,
+    Color? shadowDarkColor,
+    Color? shadowLightColorEmboss,
+    Color? shadowDarkColorEmboss,
+    Color? defaultTextColor,
+    NeumorphicBoxShape? boxShape,
+    TextTheme? textTheme,
+    NeumorphicStyle? buttonStyle,
+    IconThemeData? iconTheme,
+    NeumorphicAppBarThemeData? appBarTheme,
+    NeumorphicStyle? defaultStyle,
+    bool? disableDepth,
+    double? depth,
+    double? intensity,
+    Color? borderColor,
+    double? borderSize,
+    LightSource? lightSource,
   }) {
     return new NeumorphicThemeData(
       baseColor: baseColor ?? this.baseColor,
@@ -240,31 +240,31 @@ class NeumorphicThemeData {
   /// Create a copy of this theme
   /// With possibly new values given from the given second theme
   NeumorphicThemeData copyFrom({
-    NeumorphicThemeData other,
+    required NeumorphicThemeData other,
   }) {
     return new NeumorphicThemeData(
-      baseColor: other.baseColor ?? this.baseColor,
-      accentColor: other.accentColor ?? this.accentColor,
-      variantColor: other.variantColor ?? this.variantColor,
-      disableDepth: other.disableDepth ?? this.disableDepth,
-      disabledColor: other.disabledColor ?? this.disabledColor,
-      defaultTextColor: other.defaultTextColor ?? this.defaultTextColor,
-      shadowDarkColor: other.shadowDarkColor ?? this.shadowDarkColor,
-      shadowLightColor: other.shadowLightColor ?? this.shadowLightColor,
+      baseColor: other.baseColor,
+      accentColor: other.accentColor,
+      variantColor: other.variantColor,
+      disableDepth: other.disableDepth,
+      disabledColor: other.disabledColor,
+      defaultTextColor: other.defaultTextColor,
+      shadowDarkColor: other.shadowDarkColor,
+      shadowLightColor: other.shadowLightColor,
       shadowDarkColorEmboss:
-          other.shadowDarkColorEmboss ?? this.shadowDarkColorEmboss,
+          other.shadowDarkColorEmboss,
       shadowLightColorEmboss:
-          other.shadowLightColorEmboss ?? this.shadowLightColorEmboss,
-      textTheme: other.textTheme ?? this.textTheme,
-      iconTheme: other.iconTheme ?? this.iconTheme,
-      buttonStyle: other.buttonStyle ?? this.buttonStyle,
-      appBarTheme: other.appBarTheme ?? this.appBarTheme,
+          other.shadowLightColorEmboss,
+      textTheme: other.textTheme,
+      iconTheme: other.iconTheme,
+      buttonStyle: other.buttonStyle,
+      appBarTheme: other.appBarTheme,
       depth: other.depth ?? this._depth,
-      boxShape: other.boxShape ?? this.boxShape,
-      borderColor: other.borderColor ?? this.borderColor,
-      borderWidth: other.borderWidth ?? this.borderWidth,
+      boxShape: other.boxShape,
+      borderColor: other.borderColor,
+      borderWidth: other.borderWidth,
       intensity: other.intensity ?? this._intensity,
-      lightSource: other.lightSource ?? this.lightSource,
+      lightSource: other.lightSource,
     );
   }
 }
@@ -279,8 +279,8 @@ const neumorphicDefaultDarkTheme = NeumorphicThemeData.dark();
 
 class NeumorphicBorder {
   final bool isEnabled;
-  final Color color;
-  final double width;
+  final Color? color;
+  final double? width;
 
   const NeumorphicBorder({
     this.isEnabled = true,
@@ -310,22 +310,21 @@ class NeumorphicBorder {
     return 'NeumorphicBorder{isEnabled: $isEnabled, color: $color, width: $width}';
   }
 
-  static NeumorphicBorder lerp(
-      NeumorphicBorder a, NeumorphicBorder b, double t) {
-    assert(t != null);
-
+  static NeumorphicBorder? lerp(
+      NeumorphicBorder? a, NeumorphicBorder? b, double t) {
     if (a == null && b == null) return null;
 
     if (t == 0.0) return a;
     if (t == 1.0) return b;
 
     return NeumorphicBorder(
-        color: Color.lerp(a.color, b.color, t),
+        color: Color.lerp(a!.color, b!.color, t),
         isEnabled: a.isEnabled,
-        width: lerpDouble(a.width, b.width, t));
+        width: lerpDouble(a.width, b.width, t),
+    );
   }
 
-  NeumorphicBorder copyWithThemeIfNull({Color color, double width}) {
+  NeumorphicBorder copyWithThemeIfNull({Color? color, double? width}) {
     return NeumorphicBorder(
       isEnabled: this.isEnabled,
       color: this.color ?? color,
@@ -335,32 +334,32 @@ class NeumorphicBorder {
 }
 
 class NeumorphicStyle {
-  final Color color;
-  final double _depth;
-  final double _intensity;
+  final Color? color;
+  final double? _depth;
+  final double? _intensity;
   final double _surfaceIntensity;
-  final LightSource lightSource;
-  final bool disableDepth;
+  final LightSource? lightSource;
+  final bool? disableDepth;
 
   final NeumorphicBorder border;
 
   final bool oppositeShadowLightSource;
 
   final NeumorphicShape shape;
-  final NeumorphicBoxShape boxShape;
-  final NeumorphicThemeData theme;
+  final NeumorphicBoxShape? boxShape;
+  final NeumorphicThemeData? theme;
 
   //override the "white" color
-  final Color shadowLightColor;
+  final Color? shadowLightColor;
 
   //override the "dark" color
-  final Color shadowDarkColor;
+  final Color? shadowDarkColor;
 
   //override the "white" color
-  final Color shadowLightColorEmboss;
+  final Color? shadowLightColorEmboss;
 
   //override the "dark" color
-  final Color shadowDarkColorEmboss;
+  final Color? shadowDarkColorEmboss;
 
   const NeumorphicStyle({
     this.shape = _defaultShape,
@@ -372,8 +371,8 @@ class NeumorphicStyle {
     this.shadowDarkColor,
     this.shadowLightColorEmboss,
     this.shadowDarkColorEmboss,
-    double depth,
-    double intensity,
+    double? depth,
+    double? intensity,
     double surfaceIntensity = 0.25,
     this.disableDepth,
     this.oppositeShadowLightSource = false,
@@ -396,19 +395,19 @@ class NeumorphicStyle {
     this.shadowDarkColorEmboss,
     this.oppositeShadowLightSource = false,
     this.disableDepth,
-    double depth,
-    double intensity,
+    double? depth,
+    double? intensity,
     double surfaceIntensity = 0.25,
   })  : this._depth = depth,
         this._intensity = intensity,
         this._surfaceIntensity = surfaceIntensity;
 
-  double get depth => _depth?.clamp(Neumorphic.MIN_DEPTH, Neumorphic.MAX_DEPTH);
+  double? get depth => _depth?.clamp(Neumorphic.MIN_DEPTH, Neumorphic.MAX_DEPTH);
 
-  double get intensity =>
+  double? get intensity =>
       _intensity?.clamp(Neumorphic.MIN_INTENSITY, Neumorphic.MAX_INTENSITY);
 
-  double get surfaceIntensity => _surfaceIntensity?.clamp(
+  double get surfaceIntensity => _surfaceIntensity.clamp(
       Neumorphic.MIN_INTENSITY, Neumorphic.MAX_INTENSITY);
 
   NeumorphicStyle copyWithThemeIfNull(NeumorphicThemeData theme) {
@@ -473,21 +472,21 @@ class NeumorphicStyle {
       theme.hashCode;
 
   NeumorphicStyle copyWith({
-    Color color,
-    NeumorphicBorder border,
-    NeumorphicBoxShape boxShape,
-    Color shadowLightColor,
-    Color shadowDarkColor,
-    Color shadowLightColorEmboss,
-    Color shadowDarkColorEmboss,
-    double depth,
-    double intensity,
-    double surfaceIntensity,
-    LightSource lightSource,
-    bool disableDepth,
-    double borderRadius,
-    bool oppositeShadowLightSource,
-    NeumorphicShape shape,
+    Color? color,
+    NeumorphicBorder? border,
+    NeumorphicBoxShape? boxShape,
+    Color? shadowLightColor,
+    Color? shadowDarkColor,
+    Color? shadowLightColorEmboss,
+    Color? shadowDarkColorEmboss,
+    double? depth,
+    double? intensity,
+    double? surfaceIntensity,
+    LightSource? lightSource,
+    bool? disableDepth,
+    double? borderRadius,
+    bool? oppositeShadowLightSource,
+    NeumorphicShape? shape,
   }) {
     return NeumorphicStyle._withTheme(
       color: color ?? this.color,

--- a/lib/src/theme/theme.dart
+++ b/lib/src/theme/theme.dart
@@ -6,6 +6,7 @@ import 'package:flutter/painting.dart';
 import 'package:flutter_neumorphic/src/theme/app_bar.dart';
 import 'package:flutter_neumorphic/src/widget/container.dart';
 
+import '../../flutter_neumorphic.dart';
 import '../colors.dart';
 import '../light_source.dart';
 import '../shape.dart';
@@ -338,7 +339,7 @@ class NeumorphicStyle {
   final double? _depth;
   final double? _intensity;
   final double _surfaceIntensity;
-  final LightSource? lightSource;
+  final LightSource lightSource;
   final bool? disableDepth;
 
   final NeumorphicBorder border;
@@ -363,7 +364,7 @@ class NeumorphicStyle {
 
   const NeumorphicStyle({
     this.shape = _defaultShape,
-    this.lightSource,
+    this.lightSource = LightSource.topLeft,
     this.border = const NeumorphicBorder.none(),
     this.color,
     this.boxShape, //nullable by default, will use the one defined in theme if not set
@@ -385,7 +386,7 @@ class NeumorphicStyle {
   const NeumorphicStyle._withTheme({
     this.theme,
     this.shape = _defaultShape,
-    this.lightSource,
+    this.lightSource = LightSource.topLeft,
     this.color,
     this.boxShape,
     this.border = const NeumorphicBorder.none(),
@@ -429,7 +430,7 @@ class NeumorphicStyle {
         disableDepth: this.disableDepth ?? theme.disableDepth,
         surfaceIntensity: this.surfaceIntensity,
         oppositeShadowLightSource: this.oppositeShadowLightSource,
-        lightSource: this.lightSource ?? theme.lightSource);
+        lightSource: this.lightSource);
   }
 
   @override

--- a/lib/src/theme/theme_wrapper.dart
+++ b/lib/src/theme/theme_wrapper.dart
@@ -1,6 +1,5 @@
 import 'dart:ui';
 
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
 import 'theme.dart';
@@ -12,11 +11,11 @@ export 'theme.dart';
 /// It will be accessible to the childs widgets by an InheritedWidget
 class ThemeWrapper {
   final NeumorphicThemeData theme;
-  final NeumorphicThemeData darkTheme;
+  final NeumorphicThemeData? darkTheme;
   final ThemeMode themeMode;
 
   const ThemeWrapper({
-    @required this.theme,
+    required this.theme,
     this.darkTheme,
     this.themeMode = ThemeMode.system,
   });
@@ -28,7 +27,7 @@ class ThemeWrapper {
       (themeMode == ThemeMode.system &&
           window.platformBrightness == Brightness.dark);
 
-  NeumorphicThemeData get current {
+  NeumorphicThemeData? get current {
     if (useDark) {
       return darkTheme;
     } else {
@@ -49,9 +48,9 @@ class ThemeWrapper {
   int get hashCode => theme.hashCode ^ darkTheme.hashCode ^ themeMode.hashCode;
 
   ThemeWrapper copyWith({
-    NeumorphicThemeData theme,
-    NeumorphicThemeData darkTheme,
-    ThemeMode currentTheme,
+    NeumorphicThemeData? theme,
+    NeumorphicThemeData? darkTheme,
+    ThemeMode? currentTheme,
   }) {
     return new ThemeWrapper(
       theme: theme ?? this.theme,

--- a/lib/src/widget/animation/animated_scale.dart
+++ b/lib/src/widget/animation/animated_scale.dart
@@ -21,7 +21,7 @@ import 'package:flutter/widgets.dart';
 /// This will aimate the child's scale from 1 to 0.5 in 150ms (default duration)
 ///
 class AnimatedScale extends StatefulWidget {
-  final Widget child;
+  final Widget? child;
   final double scale;
   final Duration duration;
   final Alignment alignment;
@@ -39,8 +39,8 @@ class AnimatedScale extends StatefulWidget {
 
 class _AnimatedScaleState extends State<AnimatedScale>
     with TickerProviderStateMixin {
-  AnimationController _controller;
-  Animation<double> _animation;
+  late AnimationController _controller;
+  late Animation<double> _animation;
   double oldScale = 1;
 
   @override

--- a/lib/src/widget/app.dart
+++ b/lib/src/widget/app.dart
@@ -6,38 +6,38 @@ class NeumorphicApp extends StatelessWidget {
   final ThemeMode themeMode;
   final NeumorphicThemeData theme;
   final NeumorphicThemeData darkTheme;
-  final ThemeData materialDarkTheme;
-  final ThemeData materialTheme;
-  final String initialRoute;
-  final Color color;
-  final Iterable<LocalizationsDelegate<dynamic>> localizationsDelegates;
-  final Locale locale;
-  final Widget home;
+  final ThemeData? materialDarkTheme;
+  final ThemeData? materialTheme;
+  final String? initialRoute;
+  final Color? color;
+  final Iterable<LocalizationsDelegate<dynamic>>? localizationsDelegates;
+  final Locale? locale;
+  final Widget? home;
   final Iterable<Locale> supportedLocales;
   final Map<String, WidgetBuilder> routes;
-  final RouteFactory onGenerateRoute;
-  final RouteFactory onUnknownRoute;
-  final GenerateAppTitle onGenerateTitle;
-  final GlobalKey<NavigatorState> navigatorKey;
+  final RouteFactory? onGenerateRoute;
+  final RouteFactory? onUnknownRoute;
+  final GenerateAppTitle? onGenerateTitle;
+  final GlobalKey<NavigatorState>? navigatorKey;
   final List<NavigatorObserver> navigatorObservers;
-  final InitialRouteListFactory onGenerateInitialRoutes;
+  final InitialRouteListFactory? onGenerateInitialRoutes;
   final bool debugShowCheckedModeBanner;
-  final Function(BuildContext, Widget) builder;
-  final Function(Locale, Iterable<Locale>) localeResolutionCallback;
-  final ThemeData highContrastTheme;
-  final ThemeData highContrastDarkTheme;
-  final LocaleListResolutionCallback localeListResolutionCallback;
+  final Widget Function(BuildContext, Widget?)? builder;
+  final Locale? Function(Locale?, Iterable<Locale>)? localeResolutionCallback;
+  final ThemeData? highContrastTheme;
+  final ThemeData? highContrastDarkTheme;
+  final LocaleListResolutionCallback? localeListResolutionCallback;
   final bool showPerformanceOverlay;
   final bool checkerboardRasterCacheImages;
   final bool checkerboardOffscreenLayers;
   final bool showSemanticsDebugger;
-  final Map<LogicalKeySet, Intent> shortcuts;
-  final Map<Type, Action<Intent>> actions;
+  final Map<LogicalKeySet, Intent>? shortcuts;
+  final Map<Type, Action<Intent>>? actions;
 
   final bool debugShowMaterialGrid;
 
   const NeumorphicApp({
-    Key key,
+    Key? key,
     this.title = '',
     this.color,
     this.initialRoute,

--- a/lib/src/widget/app_bar.dart
+++ b/lib/src/widget/app_bar.dart
@@ -11,7 +11,7 @@ class NeumorphicAppBar extends StatefulWidget implements PreferredSizeWidget {
   ///
   /// Typically a [Text] widget that contains a description of the current
   /// contents of the app.
-  final Widget title;
+  final Widget? title;
 
   /// A widget to display before the [title].
   ///
@@ -27,12 +27,12 @@ class NeumorphicAppBar extends StatefulWidget implements PreferredSizeWidget {
   /// widget with an [IconButton] that opens the drawer (using [Icons.menu]). If
   /// there's no [Drawer] and the parent [Navigator] can go back, the [NeumorphicAppBar]
   /// will use a [NeumorphicBackButton] that calls [Navigator.maybePop].
-  final Widget leading;
+  final Widget? leading;
 
   /// Whether the title should be centered.
   ///
   /// Defaults to being adapted to the current [TargetPlatform].
-  final bool centerTitle;
+  final bool? centerTitle;
 
   /// Widgets to display in a row after the [title] widget.
   ///
@@ -43,7 +43,7 @@ class NeumorphicAppBar extends StatefulWidget implements PreferredSizeWidget {
   /// The [actions] become the trailing component of the [NavigationToolBar] built
   /// by this widget. The height of each action is constrained to be no bigger
   /// than the toolbar's height, which is [kToolbarHeight].
-  final List<Widget> actions;
+  final List<Widget>? actions;
 
   /// Controls whether we should try to imply the leading widget if null.
   ///
@@ -65,24 +65,24 @@ class NeumorphicAppBar extends StatefulWidget implements PreferredSizeWidget {
   final double actionSpacing;
 
   /// Force background color of the app bar
-  final Color color;
+  final Color? color;
 
   /// Force color of the icon inside app bar
-  final IconThemeData iconTheme;
+  final IconThemeData? iconTheme;
 
   @override
   final Size preferredSize;
 
-  final NeumorphicStyle buttonStyle;
+  final NeumorphicStyle? buttonStyle;
 
-  final EdgeInsets buttonPadding;
+  final EdgeInsets? buttonPadding;
 
-  final TextStyle textStyle;
+  final TextStyle? textStyle;
 
   final double padding;
 
   NeumorphicAppBar({
-    Key key,
+    Key? key,
     this.title,
     this.buttonPadding,
     this.buttonStyle,
@@ -104,8 +104,7 @@ class NeumorphicAppBar extends StatefulWidget implements PreferredSizeWidget {
 
   bool _getEffectiveCenterTitle(ThemeData theme, NeumorphicThemeData nTheme) {
     if (centerTitle != null || nTheme.appBarTheme.centerTitle != null)
-      return centerTitle ?? nTheme.appBarTheme.centerTitle;
-    assert(theme.platform != null);
+      return centerTitle ?? nTheme.appBarTheme.centerTitle!;
     switch (theme.platform) {
       case TargetPlatform.android:
       case TargetPlatform.fuchsia:
@@ -114,23 +113,22 @@ class NeumorphicAppBar extends StatefulWidget implements PreferredSizeWidget {
         return false;
       case TargetPlatform.iOS:
       case TargetPlatform.macOS:
-        return actions == null || actions.length < 2;
+        return actions == null || actions!.length < 2;
     }
-    return null;
   }
 }
 
 class NeumorphicAppBarTheme extends InheritedWidget {
   final Widget child;
 
-  NeumorphicAppBarTheme({this.child}) : super(child: child);
+  NeumorphicAppBarTheme({required this.child}) : super(child: child);
 
   @override
   bool updateShouldNotify(InheritedWidget oldWidget) {
     return false;
   }
 
-  static NeumorphicAppBarTheme of(BuildContext context) {
+  static NeumorphicAppBarTheme? of(BuildContext context) {
     return context.dependOnInheritedWidgetOfExactType();
   }
 }
@@ -140,21 +138,21 @@ class NeumorphicAppBarState extends State<NeumorphicAppBar> {
   Widget build(BuildContext context) {
     final ThemeData theme = Theme.of(context);
     final nTheme = NeumorphicTheme.of(context);
-    final ModalRoute<dynamic> parentRoute = ModalRoute.of(context);
+    final ModalRoute<dynamic>? parentRoute = ModalRoute.of(context);
     final bool canPop = parentRoute?.canPop ?? false;
     final bool useCloseButton =
         parentRoute is PageRoute<dynamic> && parentRoute.fullscreenDialog;
-    final ScaffoldState scaffold = Scaffold.maybeOf(context);
+    final ScaffoldState? scaffold = Scaffold.maybeOf(context);
     final bool hasDrawer = scaffold?.hasDrawer ?? false;
     final bool hasEndDrawer = scaffold?.hasEndDrawer ?? false;
 
-    Widget leading = widget.leading;
+    Widget? leading = widget.leading;
     if (leading == null && widget.automaticallyImplyLeading) {
       if (hasDrawer) {
         leading = NeumorphicButton(
           padding: widget.buttonPadding,
           style: widget.buttonStyle,
-          child: nTheme.current.appBarTheme.icons.menuIcon,
+          child: nTheme?.current?.appBarTheme.icons.menuIcon,
           onPressed: _handleDrawerButton,
           tooltip: MaterialLocalizations.of(context).openAppDrawerTooltip,
         );
@@ -178,25 +176,25 @@ class NeumorphicAppBarState extends State<NeumorphicAppBar> {
       );
     }
 
-    Widget title = widget.title;
+    Widget? title = widget.title;
     if (title != null) {
       final AppBarTheme appBarTheme = AppBarTheme.of(context);
       title = DefaultTextStyle(
         style: (appBarTheme.textTheme?.headline5 ??
-                Theme.of(context).textTheme.headline5)
-            .merge(widget.textStyle ?? nTheme.current.appBarTheme.textStyle),
+                Theme.of(context).textTheme.headline5!)
+            .merge(widget.textStyle ?? nTheme?.current?.appBarTheme.textStyle),
         softWrap: false,
         overflow: TextOverflow.ellipsis,
         child: title,
       );
     }
 
-    Widget actions;
-    if (widget.actions != null && widget.actions.isNotEmpty) {
+    Widget? actions;
+    if (widget.actions != null && widget.actions!.isNotEmpty) {
       actions = Row(
         mainAxisSize: MainAxisSize.min,
         crossAxisAlignment: CrossAxisAlignment.stretch,
-        children: widget.actions
+        children: widget.actions!
             .map((child) => Padding(
                   padding: EdgeInsets.only(left: widget.actionSpacing),
                   child: ConstrainedBox(
@@ -214,14 +212,14 @@ class NeumorphicAppBarState extends State<NeumorphicAppBar> {
         child: NeumorphicButton(
           padding: widget.buttonPadding,
           style: widget.buttonStyle,
-          child: nTheme.current.appBarTheme.icons.menuIcon,
+          child: nTheme?.current?.appBarTheme.icons.menuIcon,
           onPressed: _handleDrawerButtonEnd,
           tooltip: MaterialLocalizations.of(context).openAppDrawerTooltip,
         ),
       );
     }
     return Container(
-      color: widget.color ?? nTheme.current.appBarTheme.color,
+      color: widget.color ?? nTheme?.current?.appBarTheme.color,
       child: SafeArea(
         bottom: false,
         child: NeumorphicAppBarTheme(
@@ -229,15 +227,15 @@ class NeumorphicAppBarState extends State<NeumorphicAppBar> {
             padding: EdgeInsets.all(widget.padding),
             child: IconTheme(
               data: widget.iconTheme ??
-                  nTheme.current.appBarTheme.iconTheme ??
-                  nTheme.current.iconTheme ??
+                  nTheme?.current?.appBarTheme.iconTheme ??
+                  nTheme?.current?.iconTheme ??
                   const IconThemeData(),
               child: NavigationToolbar(
                 leading: leading,
                 middle: title,
                 trailing: actions,
                 centerMiddle:
-                    widget._getEffectiveCenterTitle(theme, nTheme.current),
+                    widget._getEffectiveCenterTitle(theme, nTheme!.current!),
                 middleSpacing: widget.titleSpacing,
               ),
             ),

--- a/lib/src/widget/back_button.dart
+++ b/lib/src/widget/back_button.dart
@@ -3,13 +3,13 @@ import 'package:flutter/widgets.dart';
 import 'package:flutter_neumorphic/flutter_neumorphic.dart';
 
 class NeumorphicBackButton extends StatelessWidget {
-  final VoidCallback onPressed;
-  final NeumorphicStyle style;
-  final EdgeInsets padding;
+  final VoidCallback? onPressed;
+  final NeumorphicStyle? style;
+  final EdgeInsets? padding;
   final bool forward;
 
   const NeumorphicBackButton({
-    Key key,
+    Key? key,
     this.onPressed,
     this.style,
     this.padding,
@@ -18,7 +18,7 @@ class NeumorphicBackButton extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final nThemeIcons = NeumorphicTheme.of(context).current.appBarTheme.icons;
+    final nThemeIcons = NeumorphicTheme.of(context)!.current!.appBarTheme.icons;
     return NeumorphicButton(
       style: style,
       padding: padding,

--- a/lib/src/widget/background.dart
+++ b/lib/src/widget/background.dart
@@ -16,11 +16,11 @@ import 'package:flutter_neumorphic/src/theme/neumorphic_theme.dart';
 /// ```
 @immutable
 class NeumorphicBackground extends StatelessWidget {
-  final Widget child;
-  final EdgeInsets padding;
-  final EdgeInsets margin;
+  final Widget? child;
+  final EdgeInsets? padding;
+  final EdgeInsets? margin;
   final Color backendColor;
-  final BorderRadiusGeometry borderRadius;
+  final BorderRadius? borderRadius;
 
   const NeumorphicBackground({
     this.child,

--- a/lib/src/widget/button.dart
+++ b/lib/src/widget/button.dart
@@ -47,21 +47,21 @@ class NeumorphicButton extends StatefulWidget {
   static const double PRESSED_SCALE = 0.98;
   static const double UNPRESSED_SCALE = 1.0;
 
-  final Widget child;
-  final NeumorphicStyle style;
+  final Widget? child;
+  final NeumorphicStyle? style;
   final double minDistance;
-  final EdgeInsets padding;
-  final EdgeInsets margin;
-  final bool pressed; //null, true, false
+  final EdgeInsets? padding;
+  final EdgeInsets? margin;
+  final bool? pressed; //null, true, false
   final Duration duration;
   final Curve curve;
-  final NeumorphicButtonClickListener onPressed;
+  final NeumorphicButtonClickListener? onPressed;
   final bool drawSurfaceAboveChild;
   final bool provideHapticFeedback;
-  final String tooltip;
+  final String? tooltip;
 
   NeumorphicButton({
-    Key key,
+    Key? key,
     this.padding,
     this.margin = EdgeInsets.zero,
     this.child,
@@ -84,9 +84,9 @@ class NeumorphicButton extends StatefulWidget {
 }
 
 class _NeumorphicButtonState extends State<NeumorphicButton> {
-  NeumorphicStyle initialStyle;
+  late NeumorphicStyle initialStyle;
 
-  double depth;
+  late double depth;
   bool pressed = false; //overwrite widget.pressed when click for animation
 
   void updateInitialStyle() {
@@ -99,7 +99,7 @@ class _NeumorphicButtonState extends State<NeumorphicButton> {
                 ? theme.appBarTheme.buttonStyle
                 : (theme.buttonStyle ?? const NeumorphicStyle()));
         depth = widget.style?.depth ??
-            (appBarPresent ? theme.appBarTheme.buttonStyle.depth : theme.depth);
+            (appBarPresent ? theme.appBarTheme.buttonStyle.depth : theme.depth) ?? 0.0;
       });
     }
   }
@@ -147,7 +147,7 @@ class _NeumorphicButtonState extends State<NeumorphicButton> {
     if (hasFinishedAnimationDown == true && hasTapUp == true && !hasDisposed) {
       setState(() {
         pressed = false;
-        depth = initialStyle.depth;
+        depth = initialStyle.depth!;
 
         hasFinishedAnimationDown = false;
         hasTapUp = false;
@@ -167,7 +167,7 @@ class _NeumorphicButtonState extends State<NeumorphicButton> {
     final result = _build(context);
     if (widget.tooltip != null) {
       return Tooltip(
-        message: widget.tooltip,
+        message: widget.tooltip!,
         child: result,
       );
     } else {
@@ -188,7 +188,7 @@ class _NeumorphicButtonState extends State<NeumorphicButton> {
       },
       onTapUp: (details) {
         if (clickable) {
-          widget.onPressed();
+          widget.onPressed!();
         }
         hasTapUp = true;
         _resetIfTapUp();
@@ -200,7 +200,7 @@ class _NeumorphicButtonState extends State<NeumorphicButton> {
       child: AnimatedScale(
         scale: _getScale(),
         child: Neumorphic(
-          margin: widget.margin,
+          margin: widget.margin ?? const EdgeInsets.all(0),
           drawSurfaceAboveChild: widget.drawSurfaceAboveChild,
           duration: widget.duration,
           curve: widget.curve,
@@ -227,7 +227,7 @@ class _NeumorphicButtonState extends State<NeumorphicButton> {
   double _getScale() {
     if (widget.pressed != null) {
       //defined by the widget that use it
-      return widget.pressed
+      return widget.pressed!
           ? NeumorphicButton.PRESSED_SCALE
           : NeumorphicButton.UNPRESSED_SCALE;
     } else {

--- a/lib/src/widget/checkbox.dart
+++ b/lib/src/widget/checkbox.dart
@@ -15,16 +15,16 @@ typedef void NeumorphicCheckboxListener<T>(T value);
 /// selectedColor : the color when checked (default: theme.accent)
 ///
 class NeumorphicCheckboxStyle {
-  final double selectedDepth;
-  final double unselectedDepth;
-  final bool disableDepth;
-  final double selectedIntensity;
+  final double? selectedDepth;
+  final double? unselectedDepth;
+  final bool? disableDepth;
+  final double? selectedIntensity;
   final double unselectedIntensity;
-  final Color selectedColor;
-  final Color disabledColor;
-  final LightSource lightSource;
+  final Color? selectedColor;
+  final Color? disabledColor;
+  final LightSource? lightSource;
   final NeumorphicBorder border;
-  final NeumorphicBoxShape boxShape;
+  final NeumorphicBoxShape? boxShape;
 
   const NeumorphicCheckboxStyle({
     this.selectedDepth,
@@ -130,8 +130,8 @@ class NeumorphicCheckbox extends StatelessWidget {
 
   NeumorphicCheckbox({
     this.style = const NeumorphicCheckboxStyle(),
-    @required this.value,
-    @required this.onChanged,
+    required this.value,
+    required this.onChanged,
     this.curve = Neumorphic.DEFAULT_CURVE,
     this.duration = Neumorphic.DEFAULT_DURATION,
     this.padding = const EdgeInsets.symmetric(horizontal: 16.0, vertical: 12.0),
@@ -151,11 +151,11 @@ class NeumorphicCheckbox extends StatelessWidget {
     final selectedColor = this.style.selectedColor ?? theme.accentColor;
 
     final double selectedDepth =
-        -1 * (this.style.selectedDepth ?? theme.depth).abs();
+        -1 * (this.style.selectedDepth ?? theme.depth ?? 0.0).abs();
     final double unselectedDepth =
-        (this.style.unselectedDepth ?? theme.depth).abs();
+        (this.style.unselectedDepth ?? theme.depth ?? 0.0).abs();
     final double selectedIntensity =
-        (this.style.selectedIntensity ?? theme.intensity)
+        (this.style.selectedIntensity ?? theme.intensity ?? 0.0)
             .abs()
             .clamp(Neumorphic.MIN_INTENSITY, Neumorphic.MAX_INTENSITY);
     final double unselectedIntensity = this
@@ -168,7 +168,7 @@ class NeumorphicCheckbox extends StatelessWidget {
       depth = 0;
     }
 
-    Color color = isSelected ? selectedColor : null;
+    Color? color = isSelected ? selectedColor : null;
     if (!this.isEnabled) {
       color = null;
     }

--- a/lib/src/widget/clipper/neumorphic_box_shape_clipper.dart
+++ b/lib/src/widget/clipper/neumorphic_box_shape_clipper.dart
@@ -4,11 +4,11 @@ import '../../neumorphic_box_shape.dart';
 
 class NeumorphicBoxShapeClipper extends StatelessWidget {
   final NeumorphicBoxShape shape;
-  final Widget child;
+  final Widget? child;
 
-  NeumorphicBoxShapeClipper({this.shape, this.child});
+  NeumorphicBoxShapeClipper({required this.shape, this.child});
 
-  CustomClipper _getClipper(NeumorphicBoxShape shape) {
+  CustomClipper<Path>? _getClipper(NeumorphicBoxShape shape) {
     return shape.customShapePathProvider;
   }
 

--- a/lib/src/widget/close_button.dart
+++ b/lib/src/widget/close_button.dart
@@ -3,12 +3,12 @@ import 'package:flutter/widgets.dart';
 import 'package:flutter_neumorphic/flutter_neumorphic.dart';
 
 class NeumorphicCloseButton extends StatelessWidget {
-  final VoidCallback onPressed;
-  final NeumorphicStyle style;
-  final EdgeInsets padding;
+  final VoidCallback? onPressed;
+  final NeumorphicStyle? style;
+  final EdgeInsets? padding;
 
   const NeumorphicCloseButton({
-    Key key,
+    Key? key,
     this.onPressed,
     this.style,
     this.padding,
@@ -16,7 +16,7 @@ class NeumorphicCloseButton extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final nThemeIcons = NeumorphicTheme.of(context).current.appBarTheme.icons;
+    final nThemeIcons = NeumorphicTheme.of(context)!.current!.appBarTheme.icons;
     return NeumorphicButton(
       style: style,
       padding: padding,

--- a/lib/src/widget/container.dart
+++ b/lib/src/widget/container.dart
@@ -48,10 +48,10 @@ class Neumorphic extends StatelessWidget {
   static const double MIN_CURVE = 0.0;
   static const double MAX_CURVE = 1.0;
 
-  final Widget child;
+  final Widget? child;
 
-  final NeumorphicStyle style;
-  final TextStyle textStyle;
+  final NeumorphicStyle? style;
+  final TextStyle? textStyle;
   final EdgeInsets padding;
   final EdgeInsets margin;
   final Curve curve;
@@ -60,7 +60,7 @@ class Neumorphic extends StatelessWidget {
       drawSurfaceAboveChild; //if true => boxDecoration & foreground decoration, else => boxDecoration does all the work
 
   Neumorphic({
-    Key key,
+    Key? key,
     this.child,
     this.duration = Neumorphic.DEFAULT_DURATION,
     this.curve = Neumorphic.DEFAULT_CURVE,
@@ -93,8 +93,8 @@ class Neumorphic extends StatelessWidget {
 
 class _NeumorphicContainer extends StatelessWidget {
   final NeumorphicStyle style;
-  final TextStyle textStyle;
-  final Widget child;
+  final TextStyle? textStyle;
+  final Widget? child;
   final EdgeInsets margin;
   final Duration duration;
   final Curve curve;
@@ -102,27 +102,29 @@ class _NeumorphicContainer extends StatelessWidget {
   final EdgeInsets padding;
 
   _NeumorphicContainer({
-    Key key,
-    @required this.child,
-    @required this.padding,
-    @required this.margin,
-    @required this.duration,
-    @required this.curve,
-    @required this.style,
-    @required this.textStyle,
-    @required this.drawSurfaceAboveChild,
+    Key? key,
+    this.child,
+    this.textStyle,
+    required this.padding,
+    required this.margin,
+    required this.duration,
+    required this.curve,
+    required this.style,
+    required this.drawSurfaceAboveChild,
   }) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
+    final shape = this.style.boxShape ?? NeumorphicBoxShape.rect();
+
     return DefaultTextStyle(
-      style: this.textStyle ?? material.Theme.of(context).textTheme.bodyText2,
+      style: this.textStyle ?? material.Theme.of(context).textTheme.bodyText2!,
       child: AnimatedContainer(
         margin: this.margin,
         duration: this.duration,
         curve: this.curve,
         child: NeumorphicBoxShapeClipper(
-          shape: this.style.boxShape,
+          shape: shape,
           child: Padding(
             padding: this.padding,
             child: this.child,
@@ -130,19 +132,18 @@ class _NeumorphicContainer extends StatelessWidget {
         ),
         foregroundDecoration: NeumorphicDecoration(
           isForeground: true,
-          renderingByPath:
-              this.style.boxShape.customShapePathProvider.oneGradientPerPath,
+          renderingByPath: shape.customShapePathProvider.oneGradientPerPath,
           splitBackgroundForeground: this.drawSurfaceAboveChild,
           style: this.style,
-          shape: this.style.boxShape,
+          shape: shape,
         ),
         decoration: NeumorphicDecoration(
           isForeground: false,
           renderingByPath:
-              this.style.boxShape.customShapePathProvider.oneGradientPerPath,
+              shape.customShapePathProvider.oneGradientPerPath,
           splitBackgroundForeground: this.drawSurfaceAboveChild,
           style: this.style,
-          shape: this.style.boxShape,
+          shape: shape,
         ),
       ),
     );

--- a/lib/src/widget/floating_action_button.dart
+++ b/lib/src/widget/floating_action_button.dart
@@ -11,14 +11,14 @@ const BoxConstraints _kMiniSizeConstraints = BoxConstraints.tightFor(
 );
 
 class NeumorphicFloatingActionButton extends StatelessWidget {
-  final Widget child;
-  final NeumorphicButtonClickListener onPressed;
+  final Widget? child;
+  final NeumorphicButtonClickListener? onPressed;
   final bool mini;
-  final String tooltip;
-  final NeumorphicStyle style;
+  final String? tooltip;
+  final NeumorphicStyle? style;
 
   const NeumorphicFloatingActionButton({
-    Key key,
+    Key? key,
     this.mini = false,
     this.style,
     this.tooltip,

--- a/lib/src/widget/icon.dart
+++ b/lib/src/widget/icon.dart
@@ -10,14 +10,14 @@ export '../theme/neumorphic_theme.dart';
 @immutable
 class NeumorphicIcon extends StatelessWidget {
   final IconData icon;
-  final NeumorphicStyle style;
+  final NeumorphicStyle? style;
   final Curve curve;
   final double size;
   final Duration duration;
 
   NeumorphicIcon(
     this.icon, {
-    Key key,
+    Key? key,
     this.duration = Neumorphic.DEFAULT_DURATION,
     this.curve = Neumorphic.DEFAULT_CURVE,
     this.style,

--- a/lib/src/widget/indicator.dart
+++ b/lib/src/widget/indicator.dart
@@ -17,13 +17,13 @@ import 'container.dart';
 class IndicatorStyle {
   //final double borderRadius;
   final double depth;
-  final bool disableDepth;
-  final Color accent;
-  final Color variant;
-  final LightSource lightSource;
+  final bool? disableDepth;
+  final Color? accent;
+  final Color? variant;
+  final LightSource? lightSource;
 
-  final AlignmentGeometry gradientStart;
-  final AlignmentGeometry gradientEnd;
+  final AlignmentGeometry? gradientStart;
+  final AlignmentGeometry? gradientEnd;
 
   const IndicatorStyle({
     this.depth = -4,
@@ -114,7 +114,7 @@ class NeumorphicIndicator extends StatefulWidget {
   final Curve curve;
 
   const NeumorphicIndicator({
-    Key key,
+    Key? key,
     this.percent = 0.5,
     this.orientation = NeumorphicIndicatorOrientation.vertical,
     this.height = double.maxFinite,
@@ -161,8 +161,8 @@ class NeumorphicIndicator extends StatefulWidget {
 class _NeumorphicIndicatorState extends State<NeumorphicIndicator>
     with TickerProviderStateMixin {
   double oldPercent = 0;
-  AnimationController _controller;
-  Animation _animation;
+  late AnimationController _controller;
+  late Animation _animation;
 
   @override
   void initState() {

--- a/lib/src/widget/progress.dart
+++ b/lib/src/widget/progress.dart
@@ -17,20 +17,20 @@ import 'container.dart';
 class ProgressStyle {
   final double depth;
   final BorderRadius borderRadius;
-  final BorderRadius gradientBorderRadius;
-  final Color accent;
-  final Color variant;
-  final LightSource lightSource;
+  final BorderRadius? gradientBorderRadius;
+  final Color? accent;
+  final Color? variant;
+  final LightSource? lightSource;
 
-  final AlignmentGeometry progressGradientStart;
-  final AlignmentGeometry progressGradientEnd;
+  final AlignmentGeometry? progressGradientStart;
+  final AlignmentGeometry? progressGradientEnd;
   final bool disableDepth;
 
   final NeumorphicBorder border;
 
   const ProgressStyle({
-    this.depth,
-    this.disableDepth,
+    this.depth = 0,
+    this.disableDepth = false,
     this.borderRadius = const BorderRadius.all(Radius.circular(10.0)),
     this.gradientBorderRadius,
     this.accent,
@@ -87,15 +87,15 @@ class ProgressStyle {
 ///  ```
 ///
 class NeumorphicProgress extends StatefulWidget {
-  final double _percent;
+  final double? _percent;
   final double height;
   final Duration duration;
   final ProgressStyle style;
   final Curve curve;
 
   const NeumorphicProgress(
-      {Key key,
-      double percent,
+      {Key? key,
+      double? percent,
       this.height = 10,
       this.duration = const Duration(milliseconds: 300),
       this.style = const ProgressStyle(),
@@ -106,7 +106,7 @@ class NeumorphicProgress extends StatefulWidget {
   @override
   _NeumorphicProgressState createState() => _NeumorphicProgressState();
 
-  double get percent => _percent.clamp(0, 1);
+  double? get percent => _percent?.clamp(0, 1);
 
   @override
   // ignore: invalid_override_of_non_virtual_member
@@ -127,10 +127,10 @@ class NeumorphicProgress extends StatefulWidget {
 
 class _NeumorphicProgressState extends State<NeumorphicProgress>
     with TickerProviderStateMixin {
-  double oldPercent = 0;
+  double? oldPercent = 0;
 
-  AnimationController _controller;
-  Animation _animation;
+  late AnimationController _controller;
+  late Animation _animation;
 
   @override
   void initState() {
@@ -227,7 +227,7 @@ class NeumorphicProgressIndeterminate extends StatefulWidget {
   final Curve curve;
 
   const NeumorphicProgressIndeterminate({
-    Key key,
+    Key? key,
     this.height = 10,
     this.style = const ProgressStyle(),
     this.duration = const Duration(seconds: 3),
@@ -263,8 +263,8 @@ class NeumorphicProgressIndeterminate extends StatefulWidget {
 class _NeumorphicProgressIndeterminateState
     extends State<NeumorphicProgressIndeterminate>
     with TickerProviderStateMixin {
-  AnimationController _controller;
-  Animation _animation;
+  late AnimationController _controller;
+  late Animation _animation;
 
   @override
   void initState() {
@@ -358,9 +358,9 @@ class _GradientProgress extends StatelessWidget {
   }
 
   const _GradientProgress({
-    @required this.begin,
-    @required this.end,
-    @required this.colors,
-    @required this.borderRadius,
+    required this.begin,
+    required this.end,
+    required this.colors,
+    required this.borderRadius,
   });
 }

--- a/lib/src/widget/radio.dart
+++ b/lib/src/widget/radio.dart
@@ -21,20 +21,20 @@ typedef void NeumorphicRadioListener<T>(T value);
 ///   @see [NeumorphicShape] (concave, convex, flat)
 ///
 class NeumorphicRadioStyle {
-  final double selectedDepth;
-  final double unselectedDepth;
+  final double? selectedDepth;
+  final double? unselectedDepth;
   final bool disableDepth;
 
-  final Color selectedColor; //null for default
-  final Color unselectedColor; //null for unchanged color
+  final Color? selectedColor; //null for default
+  final Color? unselectedColor; //null for unchanged color
 
-  final double intensity;
-  final NeumorphicShape shape;
+  final double? intensity;
+  final NeumorphicShape? shape;
 
   final NeumorphicBorder border;
-  final NeumorphicBoxShape boxShape;
+  final NeumorphicBoxShape? boxShape;
 
-  final LightSource lightSource;
+  final LightSource? lightSource;
 
   const NeumorphicRadioStyle({
     this.selectedDepth,
@@ -42,7 +42,7 @@ class NeumorphicRadioStyle {
     this.selectedColor,
     this.unselectedColor,
     this.lightSource,
-    this.disableDepth,
+    this.disableDepth = false,
     this.boxShape,
     this.border = const NeumorphicBorder.none(),
     this.intensity,
@@ -153,12 +153,12 @@ class NeumorphicRadioStyle {
 ///
 @immutable
 class NeumorphicRadio<T> extends StatelessWidget {
-  final Widget child;
-  final T value;
-  final T groupValue;
+  final Widget? child;
+  final T? value;
+  final T? groupValue;
   final EdgeInsets padding;
   final NeumorphicRadioStyle style;
-  final NeumorphicRadioListener<T> onChanged;
+  final NeumorphicRadioListener<T?>? onChanged;
   final bool isEnabled;
 
   final Duration duration;
@@ -182,9 +182,9 @@ class NeumorphicRadio<T> extends StatelessWidget {
     if (this.onChanged != null) {
       if (this.value == this.groupValue) {
         //unselect
-        this.onChanged(null);
+        this.onChanged!(null);
       } else {
-        this.onChanged(this.value);
+        this.onChanged!(this.value);
       }
     }
   }
@@ -194,9 +194,9 @@ class NeumorphicRadio<T> extends StatelessWidget {
     final NeumorphicThemeData theme = NeumorphicTheme.currentTheme(context);
 
     final double selectedDepth =
-        -1 * (this.style.selectedDepth ?? theme.depth).abs();
+        -1 * (this.style.selectedDepth ?? theme.depth ?? 0).abs();
     final double unselectedDepth =
-        (this.style.unselectedDepth ?? theme.depth).abs();
+        (this.style.unselectedDepth ?? theme.depth ?? 0).abs();
 
     double depth = isSelected ? selectedDepth : unselectedDepth;
     if (!this.isEnabled) {

--- a/lib/src/widget/range_slider.dart
+++ b/lib/src/widget/range_slider.dart
@@ -21,16 +21,16 @@ class RangeSliderStyle {
   final double depth;
   final bool disableDepth;
   final BorderRadius borderRadius;
-  final Color accent;
-  final Color variant;
-  final LightSource lightSource;
+  final Color? accent;
+  final Color? variant;
+  final LightSource? lightSource;
 
   final NeumorphicBorder border;
   final NeumorphicBorder thumbBorder;
 
   const RangeSliderStyle({
-    this.depth,
-    this.disableDepth,
+    this.depth = 0,
+    this.disableDepth = false,
     this.borderRadius = const BorderRadius.all(Radius.circular(10)),
     this.accent,
     this.lightSource,
@@ -118,15 +118,15 @@ class NeumorphicRangeSlider extends StatefulWidget {
   final double valueHigh;
   final double max;
   final double height;
-  final double sliderHeight;
-  final NeumorphicRangeSliderLowListener onChangedLow;
-  final NeumorphicRangeSliderHighListener onChangeHigh;
-  final Function(ActiveThumb) onPanStarted;
-  final Function(ActiveThumb) onPanEnded;
-  final Widget thumb;
+  final double? sliderHeight;
+  final NeumorphicRangeSliderLowListener? onChangedLow;
+  final NeumorphicRangeSliderHighListener? onChangeHigh;
+  final Function(ActiveThumb)? onPanStarted;
+  final Function(ActiveThumb)? onPanEnded;
+  final Widget? thumb;
 
   NeumorphicRangeSlider({
-    Key key,
+    Key? key,
     this.style = const RangeSliderStyle(),
     this.min = 0,
     this.max = 10,
@@ -151,8 +151,8 @@ class NeumorphicRangeSlider extends StatefulWidget {
 }
 
 class _NeumorphicRangeSliderState extends State<NeumorphicRangeSlider> {
-  ActiveThumb _activeThumb;
-  bool _canChangeActiveThumb;
+  late ActiveThumb _activeThumb;
+  late bool _canChangeActiveThumb;
 
   @override
   Widget build(BuildContext context) {
@@ -165,8 +165,7 @@ class _NeumorphicRangeSliderState extends State<NeumorphicRangeSlider> {
     double thumbSize = widget.height * 1.5;
 
     Function panUpdate = (DragUpdateDetails details) {
-      final RenderBox box = context.findRenderObject();
-      final tapPos = box.globalToLocal(details.globalPosition);
+      final tapPos = details.localPosition;
       final newPercent = tapPos.dx / constraints.maxWidth;
       final newValue = ((widget.min + (widget.max - widget.min) * newPercent))
           .clamp(widget.min, widget.max);
@@ -176,7 +175,7 @@ class _NeumorphicRangeSliderState extends State<NeumorphicRangeSlider> {
           if (newValue < widget.valueHigh) {
             _canChangeActiveThumb = false;
             if (widget.onChangedLow != null) {
-              widget.onChangedLow(newValue);
+              widget.onChangedLow!(newValue);
             }
           } else if (_canChangeActiveThumb && details.delta.dx > 0) {
             _canChangeActiveThumb = false;
@@ -187,7 +186,7 @@ class _NeumorphicRangeSliderState extends State<NeumorphicRangeSlider> {
           if (newValue > widget.valueLow) {
             _canChangeActiveThumb = false;
             if (widget.onChangeHigh != null) {
-              widget.onChangeHigh(newValue);
+              widget.onChangeHigh!(newValue);
             }
           } else if (_canChangeActiveThumb && details.delta.dx < 0) {
             _canChangeActiveThumb = false;
@@ -214,7 +213,7 @@ class _NeumorphicRangeSliderState extends State<NeumorphicRangeSlider> {
                 _canChangeActiveThumb = true;
                 _activeThumb = ActiveThumb.low;
                 if (widget.onPanStarted != null) {
-                  widget.onPanStarted(_activeThumb);
+                  widget.onPanStarted!(_activeThumb);
                 }
               },
               onHorizontalDragUpdate: (DragUpdateDetails details) {
@@ -222,7 +221,7 @@ class _NeumorphicRangeSliderState extends State<NeumorphicRangeSlider> {
               },
               onHorizontalDragEnd: (details) {
                 if (widget.onPanEnded != null) {
-                  widget.onPanEnded(_activeThumb);
+                  widget.onPanEnded!(_activeThumb);
                 }
               },
               child: widget.thumb ??
@@ -238,7 +237,7 @@ class _NeumorphicRangeSliderState extends State<NeumorphicRangeSlider> {
                 _canChangeActiveThumb = true;
                 _activeThumb = ActiveThumb.high;
                 if (widget.onPanStarted != null) {
-                  widget.onPanStarted(_activeThumb);
+                  widget.onPanStarted!(_activeThumb);
                 }
               },
               onHorizontalDragUpdate: (DragUpdateDetails details) {
@@ -246,7 +245,7 @@ class _NeumorphicRangeSliderState extends State<NeumorphicRangeSlider> {
               },
               onHorizontalDragEnd: (details) {
                 if (widget.onPanEnded != null) {
-                  widget.onPanEnded(_activeThumb);
+                  widget.onPanEnded!(_activeThumb);
                 }
               },
               child: widget.thumb ??
@@ -297,7 +296,7 @@ class _NeumorphicRangeSliderState extends State<NeumorphicRangeSlider> {
     ]);
   }
 
-  Widget _generateThumb(BuildContext context, double size, Color color) {
+  Widget _generateThumb(BuildContext context, double size, Color? color) {
     final theme = NeumorphicTheme.currentTheme(context);
     return Neumorphic(
       style: NeumorphicStyle(

--- a/lib/src/widget/slider.dart
+++ b/lib/src/widget/slider.dart
@@ -19,16 +19,16 @@ class SliderStyle {
   final double depth;
   final bool disableDepth;
   final BorderRadius borderRadius;
-  final Color accent;
-  final Color variant;
-  final LightSource lightSource;
+  final Color? accent;
+  final Color? variant;
+  final LightSource? lightSource;
 
   final NeumorphicBorder border;
   final NeumorphicBorder thumbBorder;
 
   const SliderStyle({
-    this.depth,
-    this.disableDepth,
+    this.depth = 0,
+    this.disableDepth = false,
     this.borderRadius = const BorderRadius.all(Radius.circular(10)),
     this.accent,
     this.lightSource,
@@ -107,15 +107,15 @@ class NeumorphicSlider extends StatefulWidget {
   final double value;
   final double max;
   final double height;
-  final NeumorphicSliderListener onChanged;
-  final NeumorphicSliderListener onChangeStart;
-  final NeumorphicSliderListener onChangeEnd;
+  final NeumorphicSliderListener? onChanged;
+  final NeumorphicSliderListener? onChangeStart;
+  final NeumorphicSliderListener? onChangeEnd;
 
-  final Widget thumb;
-  final double sliderHeight;
+  final Widget? thumb;
+  final double? sliderHeight;
 
   NeumorphicSlider({
-    Key key,
+    Key? key,
     this.style = const SliderStyle(),
     this.min = 0,
     this.value = 0,
@@ -140,25 +140,24 @@ class _NeumorphicSliderState extends State<NeumorphicSlider> {
     return LayoutBuilder(builder: (context, constraints) {
       return GestureDetector(
         onPanUpdate: (DragUpdateDetails details) {
-          final RenderBox box = context.findRenderObject();
-          final tapPos = box.globalToLocal(details.globalPosition);
+          final tapPos = details.localPosition;
           final newPercent = tapPos.dx / constraints.maxWidth;
           final newValue =
               ((widget.min + (widget.max - widget.min) * newPercent))
                   .clamp(widget.min, widget.max);
 
           if (widget.onChanged != null) {
-            widget.onChanged(newValue);
+            widget.onChanged!(newValue);
           }
         },
         onPanStart: (DragStartDetails details) {
           if (widget.onChangeStart != null) {
-            widget.onChangeStart(widget.value);
+            widget.onChangeStart!(widget.value);
           }
         },
         onPanEnd: (details) {
           if (widget.onChangeEnd != null) {
-            widget.onChangeEnd(widget.value);
+            widget.onChangeEnd!(widget.value);
           }
         },
         child: _widget(context),

--- a/lib/src/widget/switch.dart
+++ b/lib/src/widget/switch.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/widgets.dart';
 import 'package:flutter_neumorphic/src/widget/animation/animated_scale.dart';
 
+import '../../flutter_neumorphic.dart';
 import '../neumorphic_box_shape.dart';
 import '../theme/neumorphic_theme.dart';
 import 'container.dart';
@@ -13,14 +14,14 @@ import 'container.dart';
 /// and [thumbShape] @see [NeumorphicShape]
 ///
 class NeumorphicSwitchStyle {
-  final double trackDepth;
-  final Color activeTrackColor;
-  final Color inactiveTrackColor;
-  final Color activeThumbColor;
-  final Color inactiveThumbColor;
-  final NeumorphicShape thumbShape;
-  final double thumbDepth;
-  final LightSource lightSource;
+  final double? trackDepth;
+  final Color? activeTrackColor;
+  final Color? inactiveTrackColor;
+  final Color? activeThumbColor;
+  final Color? inactiveThumbColor;
+  final NeumorphicShape? thumbShape;
+  final double? thumbDepth;
+  final LightSource? lightSource;
   final bool disableDepth;
 
   final NeumorphicBorder thumbBorder;
@@ -35,7 +36,7 @@ class NeumorphicSwitchStyle {
     this.inactiveThumbColor,
     this.thumbDepth,
     this.lightSource,
-    this.disableDepth,
+    this.disableDepth = false,
     this.thumbBorder = const NeumorphicBorder.none(),
     this.trackBorder = const NeumorphicBorder.none(),
   });
@@ -117,7 +118,7 @@ class NeumorphicSwitch extends StatelessWidget {
   static const MIN_EMBOSS_DEPTH = -1.0;
 
   final bool value;
-  final ValueChanged<bool> onChanged;
+  final ValueChanged<bool>? onChanged;
   final NeumorphicSwitchStyle style;
   final double height;
   final Duration duration;
@@ -126,7 +127,7 @@ class NeumorphicSwitch extends StatelessWidget {
 
   const NeumorphicSwitch({
     this.style = const NeumorphicSwitchStyle(),
-    Key key,
+    Key? key,
     this.curve = Neumorphic.DEFAULT_CURVE,
     this.duration = const Duration(milliseconds: 200),
     this.value = false,
@@ -149,7 +150,7 @@ class NeumorphicSwitch extends StatelessWidget {
               return;
             }
             if (this.onChanged != null) {
-              this.onChanged(!this.value);
+              this.onChanged!(!this.value);
             }
           },
           child: Neumorphic(
@@ -193,17 +194,18 @@ class NeumorphicSwitch extends StatelessWidget {
   }
 
   double get _thumbDepth {
-    if (!this.isEnabled) {
+    if (!this.isEnabled || this.style.thumbDepth != null) {
       return 0;
     } else
-      return this.style.thumbDepth;
+      return this.style.thumbDepth!;
   }
 
   NeumorphicShape get _getThumbShape {
     return this.style.thumbShape ?? NeumorphicShape.flat;
   }
 
-  double _getTrackDepth(double themeDepth) {
+  double? _getTrackDepth(double? themeDepth) {
+    if (themeDepth == null) return themeDepth;
     //force negative to have emboss
     final double depth = -1 * (this.style.trackDepth ?? themeDepth).abs();
     return depth.clamp(Neumorphic.MIN_DEPTH, NeumorphicSwitch.MIN_EMBOSS_DEPTH);
@@ -220,7 +222,7 @@ class NeumorphicSwitch extends StatelessWidget {
   }
 
   Color _getThumbColor(NeumorphicThemeData theme) {
-    Color color = this.value == true
+    Color? color = this.value == true
         ? this.style.activeThumbColor
         : this.style.inactiveThumbColor;
     return color ?? theme.baseColor;
@@ -228,27 +230,27 @@ class NeumorphicSwitch extends StatelessWidget {
 }
 
 class AnimatedThumb extends StatelessWidget {
-  final Color thumbColor;
+  final Color? thumbColor;
   final Alignment alignment;
   final Duration duration;
   final NeumorphicShape shape;
-  final double depth;
+  final double? depth;
   final Curve curve;
   final bool disableDepth;
   final NeumorphicBorder border;
   final LightSource lightSource;
 
   AnimatedThumb({
-    Key key,
+    Key? key,
     this.thumbColor,
-    this.alignment,
-    this.duration,
-    this.shape,
-    this.disableDepth,
+    required this.alignment,
+    required this.duration,
+    required this.shape,
     this.depth,
-    this.curve,
-    this.border,
-    this.lightSource,
+    this.curve = Curves.linear,
+    this.border = const NeumorphicBorder.none(),
+    this.lightSource = LightSource.topLeft,
+    this.disableDepth = false,
   }) : super(key: key);
 
   @override

--- a/lib/src/widget/text.dart
+++ b/lib/src/widget/text.dart
@@ -13,20 +13,20 @@ export '../theme/neumorphic_theme.dart';
 
 class NeumorphicTextStyle {
   final bool inherit;
-  final double fontSize;
-  final FontWeight fontWeight;
-  final FontStyle fontStyle;
-  final double letterSpacing;
-  final double wordSpacing;
-  final TextBaseline textBaseline;
-  final double height;
-  final Locale locale;
-  final List<ui.FontFeature> fontFeatures;
-  final TextDecoration decoration;
-  final String debugLabel;
-  final String fontFamily;
-  final List<String> fontFamilyFallback;
-  final String package;
+  final double? fontSize;
+  final FontWeight? fontWeight;
+  final FontStyle? fontStyle;
+  final double? letterSpacing;
+  final double? wordSpacing;
+  final TextBaseline? textBaseline;
+  final double? height;
+  final Locale? locale;
+  final List<ui.FontFeature>? fontFeatures;
+  final TextDecoration? decoration;
+  final String? debugLabel;
+  final String? fontFamily;
+  final List<String>? fontFamilyFallback;
+  final String? package;
   //final Color color;
   //final Color backgroundColor;
   //final Paint foreground,
@@ -94,19 +94,19 @@ class NeumorphicTextStyle {
   });
 
   NeumorphicTextStyle copyWith({
-    bool inherit,
-    String fontFamily,
-    List<String> fontFamilyFallback,
-    double fontSize,
-    FontWeight fontWeight,
-    FontStyle fontStyle,
-    double letterSpacing,
-    double wordSpacing,
-    TextBaseline textBaseline,
-    double height,
-    Locale locale,
-    List<ui.FontFeature> fontFeatures,
-    String debugLabel,
+    bool? inherit,
+    String? fontFamily,
+    List<String>? fontFamilyFallback,
+    double? fontSize,
+    FontWeight? fontWeight,
+    FontStyle? fontStyle,
+    double? letterSpacing,
+    double? wordSpacing,
+    TextBaseline? textBaseline,
+    double? height,
+    Locale? locale,
+    List<ui.FontFeature>? fontFeatures,
+    String? debugLabel,
     //Color color,
     //Color backgroundColor,
     //Paint foreground,
@@ -146,15 +146,15 @@ class NeumorphicTextStyle {
 @immutable
 class NeumorphicText extends StatelessWidget {
   final String text;
-  final NeumorphicStyle style;
+  final NeumorphicStyle? style;
   final TextAlign textAlign;
-  final NeumorphicTextStyle textStyle;
+  final NeumorphicTextStyle? textStyle;
   final Curve curve;
   final Duration duration;
 
   NeumorphicText(
     this.text, {
-    Key key,
+    Key? key,
     this.duration = Neumorphic.DEFAULT_DURATION,
     this.curve = Neumorphic.DEFAULT_CURVE,
     this.style,
@@ -191,13 +191,13 @@ class _NeumorphicText extends material.StatefulWidget {
   final TextAlign textAlign;
 
   _NeumorphicText({
-    Key key,
-    @required this.duration,
-    @required this.curve,
-    @required this.textAlign,
-    @required this.style,
-    @required this.textStyle,
-    @required this.text,
+    Key? key,
+    required this.duration,
+    required this.curve,
+    required this.textAlign,
+    required this.style,
+    required this.textStyle,
+    required this.text,
   }) : super(key: key);
 
   @override
@@ -209,8 +209,7 @@ class __NeumorphicTextState extends material.State<_NeumorphicText> {
   Widget build(BuildContext context) {
     final TextPainter _textPainter = TextPainter(
         textDirection: TextDirection.ltr, textAlign: this.widget.textAlign);
-    final textStyle =
-        this.widget.textStyle ?? material.Theme.of(context).textTheme.bodyText2;
+    final textStyle = this.widget.textStyle;
     _textPainter.text = TextSpan(
       text: this.widget.text,
       style: this.widget.textStyle,

--- a/lib/src/widget/toggle.dart
+++ b/lib/src/widget/toggle.dart
@@ -7,13 +7,13 @@ import '../theme/neumorphic_theme.dart';
 import 'container.dart';
 
 class NeumorphicToggleStyle {
-  final double depth;
-  final bool disableDepth;
+  final double? depth;
+  final bool? disableDepth;
   final BorderRadius borderRadius;
   final bool animateOpacity;
-  final Color backgroundColor;
+  final Color? backgroundColor;
   final NeumorphicBorder border;
-  final LightSource lightSource;
+  final LightSource? lightSource;
 
   const NeumorphicToggleStyle({
     this.depth,
@@ -85,8 +85,8 @@ class NeumorphicToggleStyle {
 ///  ),
 ///),
 class ToggleElement {
-  final Widget background;
-  final Widget foreground;
+  final Widget? background;
+  final Widget? foreground;
 
   ToggleElement({
     this.background,
@@ -141,12 +141,12 @@ class NeumorphicToggle extends StatelessWidget {
   final Widget thumb;
 
   final int selectedIndex;
-  final ValueChanged<int> onChanged;
-  final Function(int) onAnimationChangedFinished;
+  final ValueChanged<int>? onChanged;
+  final Function(int)? onAnimationChangedFinished;
 
-  final NeumorphicToggleStyle style;
+  final NeumorphicToggleStyle? style;
   final double height;
-  final double width;
+  final double? width;
   final Duration duration;
   final bool isEnabled;
 
@@ -157,9 +157,9 @@ class NeumorphicToggle extends StatelessWidget {
 
   const NeumorphicToggle({
     this.style = const NeumorphicToggleStyle(),
-    Key key,
-    @required this.children,
-    @required this.thumb,
+    Key? key,
+    required this.children,
+    required this.thumb,
     this.padding = const EdgeInsets.all(2),
     this.duration = const Duration(milliseconds: 200),
     this.selectedIndex = 0,
@@ -185,7 +185,7 @@ class NeumorphicToggle extends StatelessWidget {
           curve: this.movingCurve,
           onEnd: () {
             if (onAnimationChangedFinished != null) {
-              onAnimationChangedFinished(this.selectedIndex);
+              onAnimationChangedFinished!(this.selectedIndex);
             }
           },
           alignment: _alignment(),
@@ -195,7 +195,7 @@ class NeumorphicToggle extends StatelessWidget {
             heightFactor: 1,
             child: Neumorphic(
               style: NeumorphicStyle(
-                boxShape: NeumorphicBoxShape.roundRect(this.style.borderRadius),
+                boxShape: NeumorphicBoxShape.roundRect(this.style?.borderRadius ?? BorderRadius.all(Radius.circular(12))),
               ),
               margin: this.padding,
               child: this.thumb,
@@ -238,13 +238,13 @@ class NeumorphicToggle extends StatelessWidget {
   }
 
   Widget _foregroundAtIndex(int index) {
-    Widget child = (!this.displayForegroundOnlyIfSelected) ||
+    Widget? child = (!this.displayForegroundOnlyIfSelected) ||
             (this.displayForegroundOnlyIfSelected &&
                 this.selectedIndex == index)
         ? this.children[index].foreground
         : SizedBox.expand();
     //wrap with opacity animation
-    if (style.animateOpacity) {
+    if (style != null && style!.animateOpacity) {
       child = AnimatedOpacity(
         curve: this.alphaAnimationCurve,
         opacity: this.selectedIndex == index ? 1 : 0,
@@ -266,13 +266,13 @@ class NeumorphicToggle extends StatelessWidget {
   Widget _background(BuildContext context) {
     return Neumorphic(
       style: NeumorphicStyle(
-          boxShape: NeumorphicBoxShape.roundRect(this.style.borderRadius),
-          color: this.style.backgroundColor,
-          disableDepth: this.style.disableDepth,
+          boxShape: NeumorphicBoxShape.roundRect(this.style?.borderRadius ?? BorderRadius.all(Radius.circular(12))),
+          color: this.style?.backgroundColor,
+          disableDepth: this.style?.disableDepth,
           depth: _getTrackDepth(context),
           shape: NeumorphicShape.flat,
-          border: this.style.border,
-          lightSource: this.style.lightSource ??
+          border: this.style?.border ?? NeumorphicBorder.none(),
+          lightSource: this.style?.lightSource ??
               NeumorphicTheme.currentTheme(context).lightSource),
       child: SizedBox.expand(),
     );
@@ -301,13 +301,13 @@ class NeumorphicToggle extends StatelessWidget {
     final NeumorphicThemeData theme = NeumorphicTheme.currentTheme(context);
 
     //force negative to have emboss
-    final double depth = -1 * (this.style.depth ?? theme.depth).abs();
+    final double depth = -1 * (this.style?.depth ?? theme.depth)!.abs();
     return depth.clamp(Neumorphic.MIN_DEPTH, NeumorphicToggle.MIN_EMBOSS_DEPTH);
   }
 
   void _notifyOnChange(int newValue) {
     if (this.onChanged != null) {
-      this.onChanged(newValue);
+      this.onChanged!(newValue);
     }
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,7 +10,7 @@ homepage: https://github.com/Idean/Flutter-Neumorphic
 issue_tracker: https://github.com/Idean/Flutter-Neumorphic/issues
 
 environment:
-  sdk: ">=2.1.0 <3.0.0"
+  sdk: ">=2.12.0 <3.0.0"
   flutter: ">=1.13.18 <2.0.0"
 
 dependencies:


### PR DESCRIPTION
This PR aims to bring null-safety support to the package - as per #201 request.

The approach taken was to change as little as possible in terms of logic:
* Places where `@required` tag was used were replaced with `required` keyword and became non-nullable.
* Parameters that are checked for nullability somewhere down the line were set as nullable.
* If none of these two scenarios applied, used a default value.

On `slider.dart` and `range_slider.dart`, the `onPanUpdate` method declarations have had to be updated, as `context.findRenderObject()` no longer yields a `RenderBox`
(`lib/src/widget/slider.dart:143`, `lib/src/widget/range_slider.dart:168`). Instead, the tap position is now using `DragUpdateDetails.localPosition`.

Secondly, I couldn't ascertain how to regenerate the `lib/generated/i18n.dart` file, but I don't see it being used anywhere. Maybe it should be dropped?

@florent37 I hope this helps bringing the package to Null-Safety, let me know if you think I should change anything. Thanks in advance!