### PR TITLE
add default when not found target platform

### DIFF
--- a/lib/src/widget/app_bar.dart
+++ b/lib/src/widget/app_bar.dart
@@ -114,6 +114,8 @@ class NeumorphicAppBar extends StatefulWidget implements PreferredSizeWidget {
       case TargetPlatform.iOS:
       case TargetPlatform.macOS:
         return actions == null || actions!.length < 2;
+      default:
+        return false;
     }
   }
 }


### PR DESCRIPTION
missing default will be shown an error (Error: A non-null value must be returned since the return type 'bool' doesn't allow null) when lack of target platform.