### PR TITLE
fix: replace deprecated `bodyText2` with `bodyMedium` (#287)

### DIFF
--- a/lib/src/widget/container.dart
+++ b/lib/src/widget/container.dart
@@ -118,7 +118,7 @@ class _NeumorphicContainer extends StatelessWidget {
     final shape = this.style.boxShape ?? NeumorphicBoxShape.rect();
 
     return DefaultTextStyle(
-      style: this.textStyle ?? material.Theme.of(context).textTheme.bodyText2!,
+      style: this.textStyle ?? material.Theme.of(context).textTheme.bodyMedium!,
       child: AnimatedContainer(
         margin: this.margin,
         duration: this.duration,


### PR DESCRIPTION
This update addresses compatibility issues with Flutter 3.0+ by replacing deprecated `bodyText2` references in the `TextTheme` with `bodyMedium`.

### Key Changes
- Updated all instances of `bodyText2` in the codebase to `bodyMedium` as per the latest Flutter API.
- Ensured compatibility with Flutter 3.0+ where `bodyText2` is no longer supported.

### Why this change is necessary
Flutter 3.0+ has deprecated and removed several `TextTheme` properties such as `bodyText2`, causing build failures in the `flutter_neumorphic` package. Updating to the newer `bodyMedium` resolves these issues and ensures the package remains functional for all users.

Fixes #287 .
