### PR TITLE
Fix/appbartheme compat

### DIFF
--- a/lib/src/widget/app.dart
+++ b/lib/src/widget/app.dart
@@ -73,27 +73,20 @@ class NeumorphicApp extends StatelessWidget {
   }) : super(key: key);
 
   ThemeData _getMaterialTheme(NeumorphicThemeData theme) {
-    final color = theme.accentColor;
+    final brightness = ThemeData.estimateBrightnessForColor(theme.baseColor);
 
-    if (color is MaterialColor) {
-      return ThemeData(
-        primarySwatch: color,
-        textTheme: theme.textTheme,
-        iconTheme: theme.iconTheme,
-        scaffoldBackgroundColor: theme.baseColor,
-      );
-    }
+    final colorScheme = ColorScheme.fromSeed(
+      seedColor: theme.accentColor,
+      brightness: brightness,
+    ).copyWith(
+      secondary: theme.variantColor,
+    );
 
     return ThemeData(
-      primaryColor: theme.accentColor,
-      accentColor: theme.variantColor,
-      iconTheme: theme.iconTheme,
-      brightness: ThemeData.estimateBrightnessForColor(theme.baseColor),
-      primaryColorBrightness:
-          ThemeData.estimateBrightnessForColor(theme.accentColor),
-      accentColorBrightness:
-          ThemeData.estimateBrightnessForColor(theme.variantColor),
+      useMaterial3: true,
+      colorScheme: colorScheme,
       textTheme: theme.textTheme,
+      iconTheme: theme.iconTheme,
       scaffoldBackgroundColor: theme.baseColor,
     );
   }

--- a/lib/src/widget/app_bar.dart
+++ b/lib/src/widget/app_bar.dart
@@ -178,10 +178,10 @@ class NeumorphicAppBarState extends State<NeumorphicAppBar> {
 
     Widget? title = widget.title;
     if (title != null) {
-      final AppBarTheme appBarTheme = AppBarTheme.of(context);
+      final AppBarThemeData appBarTheme = AppBarTheme.of(context);
       title = DefaultTextStyle(
-        style: (appBarTheme.textTheme?.headline5 ??
-                Theme.of(context).textTheme.headline5!)
+        style: (appBarTheme.titleTextStyle ??
+                Theme.of(context).textTheme.titleLarge!)
             .merge(widget.textStyle ?? nTheme?.current?.appBarTheme.textStyle),
         softWrap: false,
         overflow: TextOverflow.ellipsis,

--- a/lib/src/widget/container.dart
+++ b/lib/src/widget/container.dart
@@ -118,7 +118,7 @@ class _NeumorphicContainer extends StatelessWidget {
     final shape = this.style.boxShape ?? NeumorphicBoxShape.rect();
 
     return DefaultTextStyle(
-      style: this.textStyle ?? material.Theme.of(context).textTheme.bodyText2!,
+      style: this.textStyle ?? material.Theme.of(context).textTheme.bodyMedium!,
       child: AnimatedContainer(
         margin: this.margin,
         duration: this.duration,


### PR DESCRIPTION
### What was changed
- Updated `AppBarTheme.of(context)` type to `AppBarThemeData`.
- Replaced `textTheme.bodyText2` with `textTheme.bodyMedium`.
- Removed deprecated `accentColor`, now using `colorScheme.copyWith(secondary: ...)`.
- Enabled `useMaterial3: true` in `ThemeData`.

### Why
Starting with Flutter 3.32+ (Material 3):
- `accentColor` has been removed.
- Several `TextTheme` getters were renamed.
- `AppBarTheme.of` now returns `AppBarThemeData`.

Without these changes the package fails to compile on the latest Flutter stable.

### How it was tested
- Built and tested on Flutter 3.32.8 (stable).
- `flutter build appbundle` completed successfully.
- Verified AppBar and text styling still follow the theme.